### PR TITLE
add fb_apt cookbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *~
+*.orig
+*.rej
 Gemfile.lock

--- a/fb_apt/README.md
+++ b/fb_apt/README.md
@@ -23,11 +23,12 @@ Attributes
 
 Usage
 -----
-To install and configure APT include `fb_apt`, which will populate the 
-repository sources in `/etc/apt/sources.list` and update the package cache 
-during the run if it's old than `node['fb_apt']['update_delay']` seconds
-(defaults to 86400). This uses the `execute[apt-get update]` resource, which
-other cookbooks can suscribe to or notify as well.
+To install and configure APT include `fb_apt`, which will populate the
+repository sources in `/etc/apt/sources.list` and update the package cache
+during the run if it's older than `node['fb_apt']['update_delay']` seconds
+(defaults to 86400). To force an update on every Chef run, set this attribute
+to 0. The actual update is done via the `execute[apt-get update]` resource,
+which other cookbooks can suscribe to or notify as well.
 
 ### Repository sources
 By default the cookbook will setup the base distribution repos based on the

--- a/fb_apt/README.md
+++ b/fb_apt/README.md
@@ -25,9 +25,9 @@ Usage
 -----
 To install and configure APT include `fb_apt`, which will populate the 
 repository sources in `/etc/apt/sources.list` and update the package cache 
-every `node['fb_apt']['update_delay']` seconds (defaults to 86400) using the 
-`execute[apt-get update]` resource (which other cookbooks can suscribe to or 
-notify).
+during the run if it's old than `node['fb_apt']['update_delay']` seconds
+(defaults to 86400). This uses the `execute[apt-get update]` resource, which
+other cookbooks can suscribe to or notify as well.
 
 ### Repository sources
 By default the cookbook will setup the base distribution repos based on the
@@ -72,10 +72,6 @@ anything in `/etc/apt/apt.conf.d`. Example:
         'Proxy' => 'http://myproxy:3412',
       },
     })
-
-Internally, `fb_apt` uses the `FB::Apt.gen_apt_conf_entry()` library function
-to generate this config file. This is an internal function that's not meant to 
-be used by other cookbooks.
 
 ### Preferences
 You can fine tune which versions of packages will be selected for installation

--- a/fb_apt/README.md
+++ b/fb_apt/README.md
@@ -27,9 +27,7 @@ To install and configure APT include `fb_apt`, which will populate the
 repository sources in `/etc/apt/sources.list` and update the package cache 
 every `node['fb_apt']['update_delay']` seconds (defaults to 86400) using the 
 `execute[apt-get update]` resource (which other cookbooks can suscribe to or 
-notify against). Note that the `node['fb_apt']['update_delay']` attribute is 
-evaluated at compile time, so you'd need to set it before including `fb_apt` if
-you'd like to customize it.
+notify).
 
 ### Repository sources
 By default the cookbook will setup the base distribution repos based on the
@@ -52,13 +50,13 @@ Repository keys can be added to `node['fb_apt']['keys']` which is a hash in the
 from the `node['fb_apt']['keyserver']` keyserver (`keys.gnupg.net` by default).
 Example:
 
-  node.default['fb_apt']['keys'] = {
-    '94558F59' => nil,
-    'F3EFDBD9' => <<-eos
-  -----BEGIN PGP PUBLIC KEY BLOCK-----
-  ...
-  eos
-  }
+    node.default['fb_apt']['keys'] = {
+      '94558F59' => nil,
+      'F3EFDBD9' => <<-eos
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    ...
+    eos
+    }
 
 Automatic key fetching can be disabled by setting the keyserver to `nil`; this 
 will produce an exception for any unspecified key. By default `fb_apt` will 
@@ -67,22 +65,25 @@ manage the keyring at `/etc/apt/trusted.gpg`; this can be customized with
 
 ### Configuration
 APT behaviour can be customized using `node['fb_apt']['config']`, which will be
-used to populate `/etc/apt/apt.conf`. Example:
+used to populate `/etc/apt/apt.conf`. Note that this will take precedence over
+anything in /etc/apt/apt.conf.d. Example:
 
-  node.default['fb_apt']['config'] = {
-    'Acquire::http' => {
+    node.default['fb_apt']['config'].merge!({
+      'Acquire::http' => {
       'Proxy' => 'http://myproxy:3412',
-    },
-  }
+      },
+    }
   
 ### Preferences
 You can fine tune which versions of packages will be selected for installation
-by tweaking APT preferences via `node['fb_apt']['preferences']`. Example:
+by tweaking APT preferences via `node['fb_apt']['preferences']`. Note that we
+clobber the contents of `/etc/apt/preferences.d` to ensure this always takes
+precedence. Example:
 
-  node.default['fb_apt']['preferences'] = {
-    'Pin dpatch package from experimental' => {
-      'Package' => 'dpatch',
-      'Pin' => 'release o=Debian,a=experimental',
-      'Pin-Priority' => 450,
+    node.default['fb_apt']['preferences'].merge!{
+      'Pin dpatch package from experimental' => {
+        'Package' => 'dpatch',
+        'Pin' => 'release o=Debian,a=experimental',
+        'Pin-Priority' => 450,
+      }
     }
-  }

--- a/fb_apt/README.md
+++ b/fb_apt/README.md
@@ -51,13 +51,11 @@ Repository keys can be added to `node['fb_apt']['keys']` which is a hash in the
 from the `node['fb_apt']['keyserver']` keyserver (`keys.gnupg.net` by default).
 Example:
 
-    node.default['fb_apt']['keys'] = {
-      '94558F59' => nil,
-      'F3EFDBD9' => <<-eos
+    node.default['fb_apt']['keys']['94558F59'] = nil
+    node.default['fb_apt']['keys']['F3EFDBD9'] = <<-eos
     -----BEGIN PGP PUBLIC KEY BLOCK-----
     ...
     eos
-    }
 
 Automatic key fetching can be disabled by setting the keyserver to `nil`; this 
 will produce an exception for any unspecified key. By default `fb_apt` will 
@@ -73,18 +71,22 @@ anything in `/etc/apt/apt.conf.d`. Example:
       'Acquire::http' => {
         'Proxy' => 'http://myproxy:3412',
       },
-    }
-  
+    })
+
+Internally, `fb_apt` uses the `FB::Apt.gen_apt_conf_entry()` library function
+to generate this config file. This is an internal function that's not meant to 
+be used by other cookbooks.
+
 ### Preferences
 You can fine tune which versions of packages will be selected for installation
 by tweaking APT preferences via `node['fb_apt']['preferences']`. Note that we
 clobber the contents of `/etc/apt/preferences.d` to ensure this always takes
 precedence. Example:
 
-    node.default['fb_apt']['preferences'].merge!{
+    node.default['fb_apt']['preferences'].merge!({
       'Pin dpatch package from experimental' => {
         'Package' => 'dpatch',
         'Pin' => 'release o=Debian,a=experimental',
         'Pin-Priority' => 450,
       }
-    }
+    })

--- a/fb_apt/README.md
+++ b/fb_apt/README.md
@@ -31,15 +31,16 @@ notify).
 
 ### Repository sources
 By default the cookbook will setup the base distribution repos based on the
-codename (as defined in `node['lsb']['codename']`). The mirror can be
-customized with `node['fb_apt']['mirror']`; if set to `nil`, base repos will
-not be included at all in `/etc/apt/sources.list`. If base repos are enabled,
-the additional `backports` and `non-free` sources can be enabled with the
+codename (as defined in `node['lsb']['codename']`) using a sensible default 
+mirror for the package sources. The mirror can be customized with 
+`node['fb_apt']['mirror']`; if set to `nil`, base repos will not be included 
+at all in `/etc/apt/sources.list`. If base repos are enabled, the additional 
+`backports` and `non-free` sources can be enabled with the 
 `node['fb_apt']['want_backports']` and `node['fb_apt']['want_non_free']`
 attributes, and source code repos can be enabled with
 `node['fb_apt']['want_source']`; these all default to `false`.
 
-Additiona repository sources can be added with `node['fb_apt']['repos']`. By
+Additional repository sources can be added with `node['fb_apt']['repos']`. By
 default `fb_apt` will clobber existing contents in `/etc/apt/sources.list.d` to
 ensure it has full control on the repository list; this can be disabled with
 `node['fb_apt']['preserve_sources_list_d']`.
@@ -66,11 +67,11 @@ manage the keyring at `/etc/apt/trusted.gpg`; this can be customized with
 ### Configuration
 APT behaviour can be customized using `node['fb_apt']['config']`, which will be
 used to populate `/etc/apt/apt.conf`. Note that this will take precedence over
-anything in /etc/apt/apt.conf.d. Example:
+anything in `/etc/apt/apt.conf.d`. Example:
 
     node.default['fb_apt']['config'].merge!({
       'Acquire::http' => {
-      'Proxy' => 'http://myproxy:3412',
+        'Proxy' => 'http://myproxy:3412',
       },
     }
   

--- a/fb_apt/attributes/default.rb
+++ b/fb_apt/attributes/default.rb
@@ -1,4 +1,12 @@
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
 
 if node.debian?
   mirror = 'http://http.debian.net/debian'

--- a/fb_apt/attributes/default.rb
+++ b/fb_apt/attributes/default.rb
@@ -1,0 +1,22 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+
+if node.debian?
+  mirror = 'http://http.debian.net/debian'
+elsif node.ubuntu?
+  mirror = 'http://archive.ubuntu.com/ubuntu'
+end
+
+default['fb_apt'] = {
+  'config' => {},
+  'repos' => [],
+  'keys' => {},
+  'keyring' => '/etc/apt/trusted.gpg',
+  'keyserver' => 'keys.gnupg.net',
+  'mirror' => mirror,
+  'preferences' => {},
+  'preserve_sources_list_d' => false,
+  'update_delay' => 86400,
+  'want_backports' => false,
+  'want_non_free' => false,
+  'want_source' => false,
+}

--- a/fb_apt/attributes/default.rb
+++ b/fb_apt/attributes/default.rb
@@ -10,14 +10,26 @@
 
 if node.debian?
   mirror = 'http://httpredir.debian.org/debian'
+  # on Debian the base keys are provided by the debian-archive-keyring package
+  # and stored in a separate keyring, so there's no need to manage them here
+  keys = {}
 elsif node.ubuntu?
   mirror = 'http://archive.ubuntu.com/ubuntu'
+  # Ubuntu Archive signing keys -- these are provided by the ubuntu-keyring
+  # package and merged into the main keyring, we list them here so they don't
+  # get clobbered
+  keys = {
+    '437D05B5' => nil,
+    'FBB75451' => nil,
+    'C0B21F32' => nil,
+    'EFE21092' => nil,
+  }
 end
 
 default['fb_apt'] = {
   'config' => {},
   'repos' => [],
-  'keys' => {},
+  'keys' => keys,
   'keyring' => '/etc/apt/trusted.gpg',
   'keyserver' => 'keys.gnupg.net',
   'mirror' => mirror,

--- a/fb_apt/attributes/default.rb
+++ b/fb_apt/attributes/default.rb
@@ -9,7 +9,7 @@
 #
 
 if node.debian?
-  mirror = 'http://http.debian.net/debian'
+  mirror = 'http://httpredir.debian.org/debian'
 elsif node.ubuntu?
   mirror = 'http://archive.ubuntu.com/ubuntu'
 end

--- a/fb_apt/libraries/default.rb
+++ b/fb_apt/libraries/default.rb
@@ -1,0 +1,39 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+module FB
+  # APT utility functions
+  class Apt
+    # Helper function to generate /etc/apt.conf entries
+    def self.gen_apt_conf_entry(k, v, i = 0)
+      indent = ' ' * i
+      if v.is_a?(Hash)
+        s = "\n#{indent}#{k} {"
+        v.each do |kk, vv|
+          s += make_option(kk, vv, i + 2)
+        end
+        s += "\n#{indent}};"
+        return s
+      elsif v.is_a?(Array)
+        s = ''
+        v.each do |vv|
+          s += make_option(k, vv, i)
+        end
+        return s
+      elsif v.is_a?(TrueClass)
+        return "\n#{indent}#{k} \"true\";"
+      elsif v.is_a?(FalseClass)
+        return "\n#{indent}#{k} \"false\";"
+      else
+        return "\n#{indent}#{k} \"#{v}\";"
+      end
+    end
+  end
+end

--- a/fb_apt/libraries/default.rb
+++ b/fb_apt/libraries/default.rb
@@ -11,20 +11,20 @@
 module FB
   # APT utility functions
   class Apt
-    # Helper function to generate /etc/apt.conf entries
-    def self.gen_apt_conf_entry(k, v, i = 0)
+    # Internal helper function to generate /etc/apt.conf entries
+    def self._gen_apt_conf_entry(k, v, i = 0)
       indent = ' ' * i
       if v.is_a?(Hash)
         s = "\n#{indent}#{k} {"
         v.each do |kk, vv|
-          s += self.gen_apt_conf_entry(kk, vv, i + 2)
+          s += self._gen_apt_conf_entry(kk, vv, i + 2)
         end
         s += "\n#{indent}};"
         return s
       elsif v.is_a?(Array)
         s = ''
         v.each do |vv|
-          s += self.gen_apt_conf_entry(k, vv, i)
+          s += self._gen_apt_conf_entry(k, vv, i)
         end
         return s
       elsif v.is_a?(TrueClass)

--- a/fb_apt/libraries/default.rb
+++ b/fb_apt/libraries/default.rb
@@ -17,14 +17,14 @@ module FB
       if v.is_a?(Hash)
         s = "\n#{indent}#{k} {"
         v.each do |kk, vv|
-          s += make_option(kk, vv, i + 2)
+          s += self.gen_apt_conf_entry(kk, vv, i + 2)
         end
         s += "\n#{indent}};"
         return s
       elsif v.is_a?(Array)
         s = ''
         v.each do |vv|
-          s += make_option(k, vv, i)
+          s += self.gen_apt_conf_entry(k, vv, i)
         end
         return s
       elsif v.is_a?(TrueClass)

--- a/fb_apt/metadata.rb
+++ b/fb_apt/metadata.rb
@@ -1,0 +1,9 @@
+name 'fb_apt'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'BSD'
+description 'Installs/Configures fb_apt'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+depends 'fb_helpers'

--- a/fb_apt/providers/keys.rb
+++ b/fb_apt/providers/keys.rb
@@ -1,0 +1,57 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+
+def whyrun_supported?
+  true
+end
+
+use_inline_resources
+
+action :run do
+  keyring = node['fb_apt']['keyring']
+  keyserver = node['fb_apt']['keyserver']
+  keys = node['fb_apt']['keys'].to_hash
+
+  if keys && keyring
+    cmd = Mixlib::ShellOut.new("LANG=C apt-key --keyring #{keyring} list")
+    cmd.run_command
+    # Note: we deliberately ignore errors here, as this will fail if the keyring
+    # doesn't exist (e.g. because there are no keys yet).
+    output = cmd.stdout.split("\n")
+    Chef::Log.debug("apt-key output: #{output.join("\n")}")
+    installed_keys = output.select { |x| x.start_with?('pub') }.map do |x|
+      x[%r/pub.*\/(?<keyid>[A-Z0-9]*)/, 'keyid']
+    end
+    Chef::Log.info("Installed keys: #{installed_keys.join(', ')}")
+
+    # Process keys to add
+    keys.each do |keyid, key|
+      if installed_keys.include?(keyid)
+        Chef::Log.debug("Skipping keyid #{keyid} as it's already registered")
+      else
+        Chef::Log.debug("Processing new keyid #{keyid}")
+        if key
+          execute "add key for #{keyid} to APT" do
+            command "echo '#{key}' | apt-key add -"
+          end
+        elsif keyserver
+          execute "fetch and add key for keyid #{keyid} to APT" do
+            command "apt-key adv --keyserver #{keyserver} --recv #{keyid}"
+          end
+        else
+          fail "Cannot fetch key for #{keyid} as keyserver is not defined"
+        end
+      end
+    end
+
+    # Process keys to remove
+    installed_keys.each do |keyid|
+      if keys.include?(keyid)
+        Chef::Log.debug("Not deleting added keyid #{keyid}")
+      else
+        execute "delete key for #{keyid} from APT" do
+          command "apt-key del #{keyid}"
+        end
+      end
+    end
+  end
+end

--- a/fb_apt/providers/keys.rb
+++ b/fb_apt/providers/keys.rb
@@ -20,6 +20,7 @@ action :run do
   keys = node['fb_apt']['keys'].to_hash
 
   if keys && keyring
+    installed_keys = []
     if ::File.exists?(keyring)
       cmd = Mixlib::ShellOut.new("LANG=C apt-key --keyring #{keyring} list")
       cmd.run_command
@@ -29,11 +30,8 @@ action :run do
       installed_keys = output.select { |x| x.start_with?('pub') }.map do |x|
         x[%r/pub.*\/(?<keyid>[A-Z0-9]*)/, 'keyid']
       end
-      Chef::Log.info("Installed keys: #{installed_keys.join(', ')}")
-    else
-      installed_keys = []
-      Chef::Log.info('Keyring not found, assuming no keys are installed.')
     end
+    Chef::Log.debug("Installed keys: #{installed_keys.join(', ')}")
 
     # Process keys to add
     keys.each do |keyid, key|

--- a/fb_apt/providers/sources_list.rb
+++ b/fb_apt/providers/sources_list.rb
@@ -1,0 +1,70 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+
+def whyrun_supported?
+  true
+end
+
+use_inline_resources
+
+action :run do
+  repos = []
+  mirror = node['fb_apt']['mirror']
+  distro = node['lsb']['codename']
+
+  # only add base repos if mirror is set and codename is available
+  if mirror && distro
+    components = 'main'
+    if node.ubuntu?
+      components += ' universe'
+    end
+
+    if node['fb_apt']['want_non_free']
+      if node.debian?
+        components += ' contrib non-free'
+      elsif node.ubuntu?
+        components += ' restricted multiverse'
+      else
+        fail "Don't know how to setup non-free for #{node['platform']}"
+      end
+    end
+
+    base_repos = [
+      # Main repo
+      "#{mirror} #{distro} #{components}",
+    ]
+
+    # Security updates
+    if node.debian?
+      base_repos <<
+        "http://security.debian.org/ #{distro}/updates #{components}"
+    elsif node.ubuntu?
+      base_repos <<
+        "http://security.ubuntu.com/ #{distro}-security #{components}"
+    end
+
+    # Stable updates
+    base_repos << "#{mirror} #{distro}-updates #{components}"
+
+    if node['fb_apt']['want_backports']
+      base_repos << "#{mirror} #{distro}-backports #{components}"
+    end
+
+    base_repos.each do |repo|
+      repos << "deb #{repo}"
+      if node['fb_apt']['want_source']
+        repos << "deb-src #{repo}"
+      end
+    end
+  end
+
+  # add custom repos
+  repos += node['fb_apt']['repos']
+
+  template '/etc/apt/sources.list' do
+    source 'sources.list.erb'
+    owner 'root'
+    group 'root'
+    mode '0644'
+    variables(:repos => repos)
+  end
+end

--- a/fb_apt/providers/sources_list.rb
+++ b/fb_apt/providers/sources_list.rb
@@ -1,4 +1,12 @@
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
 
 def whyrun_supported?
   true
@@ -13,40 +21,41 @@ action :run do
 
   # only add base repos if mirror is set and codename is available
   if mirror && distro
-    components = 'main'
+    components = %w{main}
     if node.ubuntu?
-      components += ' universe'
+      components << 'universe'
     end
 
     if node['fb_apt']['want_non_free']
       if node.debian?
-        components += ' contrib non-free'
+        components += %w{contrib non-free}
       elsif node.ubuntu?
-        components += ' restricted multiverse'
+        components += %w{restricted multiverse}
       else
         fail "Don't know how to setup non-free for #{node['platform']}"
       end
     end
 
+    components_entry = components.join(' ')
     base_repos = [
       # Main repo
-      "#{mirror} #{distro} #{components}",
+      "#{mirror} #{distro} #{components_entry}",
     ]
 
     # Security updates
-    if node.debian?
+    if node.debian? && distro != 'sid'
       base_repos <<
-        "http://security.debian.org/ #{distro}/updates #{components}"
+        "http://security.debian.org/ #{distro}/updates #{components_entry}"
     elsif node.ubuntu?
       base_repos <<
-        "http://security.ubuntu.com/ #{distro}-security #{components}"
+        "http://security.ubuntu.com/ #{distro}-security #{components_entry}"
     end
 
     # Stable updates
-    base_repos << "#{mirror} #{distro}-updates #{components}"
+    base_repos << "#{mirror} #{distro}-updates #{components_entry}"
 
     if node['fb_apt']['want_backports']
-      base_repos << "#{mirror} #{distro}-backports #{components}"
+      base_repos << "#{mirror} #{distro}-backports #{components_entry}"
     end
 
     base_repos.each do |repo|

--- a/fb_apt/providers/sources_list.rb
+++ b/fb_apt/providers/sources_list.rb
@@ -51,11 +51,14 @@ action :run do
         "http://security.ubuntu.com/ #{distro}-security #{components_entry}"
     end
 
-    # Stable updates
-    base_repos << "#{mirror} #{distro}-updates #{components_entry}"
+    # Debian Sid doesn't have updates or backports
+    unless node.debian? && distro == 'sid'
+      # Stable updates
+      base_repos << "#{mirror} #{distro}-updates #{components_entry}"
 
-    if node['fb_apt']['want_backports']
-      base_repos << "#{mirror} #{distro}-backports #{components_entry}"
+      if node['fb_apt']['want_backports']
+        base_repos << "#{mirror} #{distro}-backports #{components_entry}"
+      end
     end
 
     base_repos.each do |repo|

--- a/fb_apt/providers/sources_list.rb
+++ b/fb_apt/providers/sources_list.rb
@@ -15,7 +15,6 @@ end
 use_inline_resources
 
 action :run do
-  repos = []
   mirror = node['fb_apt']['mirror']
   distro = node['lsb']['codename']
 
@@ -61,22 +60,22 @@ action :run do
       end
     end
 
+    repos = []
     base_repos.each do |repo|
       repos << "deb #{repo}"
       if node['fb_apt']['want_source']
         repos << "deb-src #{repo}"
       end
     end
-  end
 
-  # add custom repos
-  repos += node['fb_apt']['repos']
+    # update repos list and ensure base repos come first
+    node.default['fb_apt']['repos'] = repos + node['fb_apt']['repos']
+  end
 
   template '/etc/apt/sources.list' do
     source 'sources.list.erb'
     owner 'root'
     group 'root'
     mode '0644'
-    variables(:repos => repos)
   end
 end

--- a/fb_apt/recipes/default.rb
+++ b/fb_apt/recipes/default.rb
@@ -18,6 +18,15 @@ package 'apt' do
   action :upgrade
 end
 
+keyring_package = value_for_platform(
+  'debian' => 'debian-archive-keyring',
+  'ubuntu' => 'ubuntu-keyring',
+)
+
+package keyring_package do
+  action :upgrade
+end
+
 # This takes precedence over anything in /etc/apt/apt.conf.d. We can't just
 # clobber that as several packages will drop configs there.
 template '/etc/apt/apt.conf' do

--- a/fb_apt/recipes/default.rb
+++ b/fb_apt/recipes/default.rb
@@ -65,7 +65,8 @@ execute 'apt-get update' do
   action :nothing
 end
 
-ruby_block 'periodic package cache update' do
+# Dummy resource to trigger an update when the package cache goes stale.
+log 'periodic package cache update' do
   only_if do
     pkgcache = '/var/cache/apt/pkgcache.bin'
     !::File.exists?(pkgcache) || (

--- a/fb_apt/recipes/default.rb
+++ b/fb_apt/recipes/default.rb
@@ -1,0 +1,73 @@
+#
+# Cookbook Name:: fb_apt
+# Recipe:: default
+#
+# Copyright 2014, Davide Cavalca
+#
+
+unless node.debian? || node.ubuntu?
+  fail 'fb_apt is only supported on Debian and Ubuntu.'
+end
+
+package 'apt' do
+  action :upgrade
+end
+
+# This takes precedence over anything in /etc/apt/apt.conf.d. We can't just
+# clobber that as several packages will drop configs there.
+template '/etc/apt/apt.conf' do
+  source 'apt.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :run, 'execute[apt-get update]'
+end
+
+# No sane package should drop stuff here, and bad preferences can seriously
+# mess up a machine, so let's clobber it to be safe.
+Dir.glob('/etc/apt/preferences.d/*').each do |f|
+  file f do
+    action :delete
+  end
+end
+
+template '/etc/apt/preferences' do
+  source 'preferences.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end
+
+fb_apt_keys 'process keys' do
+  notifies :run, 'execute[apt-get update]'
+end
+
+# On Debian nothing should drop things here, but Ubuntu likes to use it for its
+# default sources, so we optionally allow keeping its contents
+Dir.glob('/etc/apt/sources.list.d/*').each do |f|
+  file f do
+    not_if { node['fb_apt']['preserve_sources_list_d'] }
+    action :delete
+  end
+end
+
+fb_apt_sources_list 'populate sources list' do
+  notifies :run, 'execute[apt-get update]', :immediately
+end
+
+# TODO: this should be done at runtime
+pkgcache = '/var/cache/apt/pkgcache.bin'
+pkgcache_is_stale = !::File.exists?(pkgcache) || (
+  ::File.exists?(pkgcache) &&
+  ::File.mtime(pkgcache) < Time.now - node['fb_apt']['update_delay'])
+
+if pkgcache_is_stale
+  update_action = :run
+else
+  update_action = :nothing
+end
+
+execute 'apt-get update' do
+  command 'apt-get update'
+  action update_action
+end

--- a/fb_apt/resources/keys.rb
+++ b/fb_apt/resources/keys.rb
@@ -1,0 +1,4 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+
+actions :run
+default_action :run

--- a/fb_apt/resources/keys.rb
+++ b/fb_apt/resources/keys.rb
@@ -1,4 +1,12 @@
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
 
 actions :run
 default_action :run

--- a/fb_apt/resources/sources_list.rb
+++ b/fb_apt/resources/sources_list.rb
@@ -1,0 +1,4 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+
+actions :run
+default_action :run

--- a/fb_apt/resources/sources_list.rb
+++ b/fb_apt/resources/sources_list.rb
@@ -1,4 +1,12 @@
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
 
 actions :run
 default_action :run

--- a/fb_apt/spec/public_spec.rb
+++ b/fb_apt/spec/public_spec.rb
@@ -1,0 +1,49 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+# we know relative_requires is bad, but it allows us to handle pathing
+# differences between internal repo and github
+require_relative '../libraries/default'
+
+describe 'FB::Apt' do
+  control = <<-eos
+// This file is maintained by Chef. Do not edit, all changes will be
+// overwritten. See fb_apt/README.md
+
+Acquire::http {
+  Proxy "http://myproxy:3412";
+};
+APT {
+  Default-Release "stable";
+  Cache-Limit "10000000";
+};
+  eos
+  # remove trailing newline added by the heredoc
+  control.chomp!
+
+  it 'should generate apt.conf' do
+    generated = <<-eos
+// This file is maintained by Chef. Do not edit, all changes will be
+// overwritten. See fb_apt/README.md
+    eos
+    {
+      'Acquire::http' => {
+        'Proxy' => 'http://myproxy:3412',
+      },
+      'APT' => {
+        'Default-Release' => 'stable',
+        'Cache-Limit' => 10000000,
+      },
+    }.each do |key, val|
+      generated += FB::Apt.gen_apt_conf_entry(key, val)
+    end
+    expect(generated).to eq(control)
+  end
+end

--- a/fb_apt/spec/public_spec.rb
+++ b/fb_apt/spec/public_spec.rb
@@ -42,7 +42,7 @@ APT {
         'Cache-Limit' => 10000000,
       },
     }.each do |key, val|
-      generated += FB::Apt.gen_apt_conf_entry(key, val)
+      generated += FB::Apt._gen_apt_conf_entry(key, val)
     end
     expect(generated).to eq(control)
   end

--- a/fb_apt/templates/default/apt.conf.erb
+++ b/fb_apt/templates/default/apt.conf.erb
@@ -1,5 +1,5 @@
 // This file is maintained by Chef. Do not edit, all changes will be
 // overwritten. See fb_apt/README.md
 <% node['fb_apt']['config'].to_hash.each do |key, val| -%>
-<%=  FB::Apt.gen_apt_conf_entry(key, val) %>
+<%=  FB::Apt._gen_apt_conf_entry(key, val) %>
 <% end -%>

--- a/fb_apt/templates/default/apt.conf.erb
+++ b/fb_apt/templates/default/apt.conf.erb
@@ -1,30 +1,5 @@
 // This file is maintained by Chef. Do not edit, all changes will be
 // overwritten. See fb_apt/README.md
-<%
-  def make_option(k, v, i)
-    indent = ' ' * i
-    if v.is_a?(Hash)
-      s = "\n#{indent}#{k} {"
-      v.each do |kk, vv|
-        s += make_option(kk, vv, i+2)
-      end
-      s += "\n#{indent}};"
-      return s
-    elsif v.is_a?(Array)
-      s = ''
-      v.each do |vv|
-        s += make_option(k, vv, i)
-      end
-      return s
-    elsif v.is_a?(TrueClass)
-      return "\n#{indent}#{k} \"true\";"
-    elsif v.is_a?(FalseClass)
-      return "\n#{indent}#{k} \"false\";"
-    else
-      return "\n#{indent}#{k} \"#{v}\";"
-    end
-  end
-
-  node['fb_apt']['config'].to_hash.each do |key, val| -%>
-<%= make_option(key, val, 0) %>
+<% node['fb_apt']['config'].to_hash.each do |key, val| -%>
+<%=  FB::Apt.gen_apt_conf_entry(key, val) %>
 <% end -%>

--- a/fb_apt/templates/default/apt.conf.erb
+++ b/fb_apt/templates/default/apt.conf.erb
@@ -1,0 +1,30 @@
+// This file is maintained by Chef. Do not edit, all changes will be
+// overwritten. See fb_apt/README.md
+<%
+  def make_option(k, v, i)
+    indent = ' ' * i
+    if v.is_a?(Hash)
+      s = "\n#{indent}#{k} {"
+      v.each do |kk, vv|
+        s += make_option(kk, vv, i+2)
+      end
+      s += "\n#{indent}};"
+      return s
+    elsif v.is_a?(Array)
+      s = ''
+      v.each do |vv|
+        s += make_option(k, vv, i)
+      end
+      return s
+    elsif v.is_a?(TrueClass)
+      return "\n#{indent}#{k} \"true\";"
+    elsif v.is_a?(FalseClass)
+      return "\n#{indent}#{k} \"false\";"
+    else
+      return "\n#{indent}#{k} \"#{v}\";"
+    end
+  end
+
+  node['fb_apt']['config'].to_hash.each do |key, val| -%>
+<%= make_option(key, val, 0) %>
+<% end -%>

--- a/fb_apt/templates/default/preferences.erb
+++ b/fb_apt/templates/default/preferences.erb
@@ -1,0 +1,7 @@
+<% node['fb_apt']['preferences'].to_hash.each do |explanation, config| -%>
+Explanation: <%= explanation %>
+<%   config.each do |key, val| -%>
+<%=    key %>: <%= val %>
+<%   end -%>
+
+<% end -%>

--- a/fb_apt/templates/default/sources.list.erb
+++ b/fb_apt/templates/default/sources.list.erb
@@ -1,6 +1,6 @@
 # This file is maintained by Chef. Do not edit, all changes will be
 # overwritten. See fb_apt/README.md
 
-<% @repos.each do |repo| -%>
+<% node['fb_apt']['repos'].each do |repo| -%>
 <%=  repo %>
 <% end -%>

--- a/fb_apt/templates/default/sources.list.erb
+++ b/fb_apt/templates/default/sources.list.erb
@@ -1,0 +1,6 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_apt/README.md
+
+<% @repos.each do |repo| -%>
+<%=  repo %>
+<% end -%>

--- a/fb_helpers/README.md
+++ b/fb_helpers/README.md
@@ -26,6 +26,9 @@ your node.
 * `node.centos7?`
     Is CentOS7
 
+* `node.debian?`
+    Is Debian
+
 * `node.ubuntu?`
     Is Ubuntu
 

--- a/fb_helpers/libraries/node_methods.rb
+++ b/fb_helpers/libraries/node_methods.rb
@@ -24,6 +24,10 @@ class Chef
       return self.centos? && self['platform_version'].start_with?('5')
     end
 
+    def debian?
+      return self['platform'] == 'debian'
+    end
+
     def ubuntu?
       return self['platform'] == 'ubuntu'
     end


### PR DESCRIPTION
This adds a cookbook to manage APT using the attribute-driven API. It's a rework of an unpublished cookbook I've been running at home for a while. It tries to fully manage everything around APT, including keys and configurations. Tested only on Debian but includes code to support Ubuntu as well; should be trivial to port to other Debian-based distros.