### PR TITLE
add fb_dnsmasq cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -34,4 +34,6 @@ provisioner:
 
 suites:
   - name: default
-    run_list: recipe[fb_init_sample]
+    run_list:
+      - recipe[fb_init_sample]
+      - recipe[fb_dnsmasq]

--- a/cookbooks/fb_dnsmasq/README.md
+++ b/cookbooks/fb_dnsmasq/README.md
@@ -1,0 +1,40 @@
+fb_dnsmasq Cookbook
+====================
+This cookbook installs and configures dnsmasq, a small caching DNS proxy and
+DHCP/TFTP server.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_dnsmasq']['config']
+
+Usage
+-----
+Include `fb_dnsmasq` in your runlist to install dnsmasq and enable its service.
+Configuration can be customized using `node['fb_dnsmasq']['config']` according
+to the [upstream documentation](http://www.thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html). Example:
+
+    node.default['fb_dnsmasq']['config'] = {
+      'dhcp-authoritative' => nil,
+      'dhcp-range' => [
+        '192.168.1.100,192.168.1.200,12h',
+        '::1,constructor:eth0,ra-stateless,ra-names',
+       ],
+      'enable-ra' => nil,
+      'server' => [
+        '8.8.8.8',
+        '8.8.4.4',
+       ],
+      'no-resolv' => nil,
+      'read-ethers' => nil,
+    }
+
+Unless the `no-hosts` config option is set, dnsmasq will read hostname to IP
+mappings from `/etc/hosts`. This can be customized using the API provided by
+the `fb_hosts` cookbook.
+
+If the `read-ethers` config option is set, dnsmasq will read mac address to 
+hostname mappings from `/etc/ethers`. This can be customized using the API
+provided by the `fb_ethers` cookbook.

--- a/cookbooks/fb_dnsmasq/README.md
+++ b/cookbooks/fb_dnsmasq/README.md
@@ -9,10 +9,12 @@ Requirements
 Attributes
 ----------
 * node['fb_dnsmasq']['config']
+* node['fb_dnsmasq']['enable']
 
 Usage
 -----
-Include `fb_dnsmasq` in your runlist to install dnsmasq and enable its service.
+Include `fb_dnsmasq` in your runlist to install dnsmasq. By default we enable
+the daemon, set `node['fb_dnsmasq']['enable']` to `false` to disable it.
 Configuration can be customized using `node['fb_dnsmasq']['config']` according
 to the [upstream documentation](http://www.thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html). Example:
 

--- a/cookbooks/fb_dnsmasq/attributes/default.rb
+++ b/cookbooks/fb_dnsmasq/attributes/default.rb
@@ -1,0 +1,14 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+default['fb_dnsmasq'] = {
+  'config' => {},
+  'enable' => true,
+}

--- a/cookbooks/fb_dnsmasq/metadata.rb
+++ b/cookbooks/fb_dnsmasq/metadata.rb
@@ -1,0 +1,10 @@
+name 'fb_dnsmasq'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'BSD'
+description 'Installs/Configures fb_dnsmasq'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+depends 'fb_ethers'
+depends 'fb_hosts'

--- a/cookbooks/fb_dnsmasq/recipes/default.rb
+++ b/cookbooks/fb_dnsmasq/recipes/default.rb
@@ -1,0 +1,35 @@
+#
+# Cookbook Name:: fb_dnsmasq
+# Recipe:: default
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+package 'dnsmasq' do
+  action :upgrade
+end
+
+template '/etc/dnsmasq.conf' do
+  source 'dnsmasq.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[dnsmasq]'
+end
+
+service 'dnsmasq' do
+  only_if { node['fb_dnsmasq']['enable'] }
+  action [:enable, :start]
+  subscribes :restart, 'template[/etc/hosts]'
+  subscribes :restart, 'template[/etc/ethers]'
+end
+
+service 'disable dnsmasq' do
+  not_if { node['fb_dnsmasq']['enable'] }
+  action [:stop, :disable]
+end

--- a/cookbooks/fb_dnsmasq/templates/default/dnsmasq.conf.erb
+++ b/cookbooks/fb_dnsmasq/templates/default/dnsmasq.conf.erb
@@ -1,0 +1,17 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_dnsmasq/README.md
+
+<% node['fb_dnsmasq']['config'].to_hash.each do |key, val|
+     if val
+       if val.is_a?(Array)
+         vals = val
+       else
+         vals = [val]
+       end
+       vals.each do |v| -%>
+<%=      key %><% if v %>=<%= v %><% end %>
+<%     end -%>
+<%   else -%>
+<%=    key %>
+<%   end -%>
+<% end -%>

--- a/cookbooks/fb_ethers/README.md
+++ b/cookbooks/fb_ethers/README.md
@@ -1,0 +1,22 @@
+fb_ethers Cookbook
+====================
+This cookbook configures `/etc/ethers` and provides an API for modifying all
+aspects of the `/etc/ethers` file.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_ethers']['entries']
+
+Usage
+-----
+Add MAC address to hostname mappings using the `node['fb_ethers']['entries']`
+attribute. Example:
+
+    node.default['fb_ethers']['entries'] = {
+      'fc:15:b4:8f:3b:34' => 'foo01',
+      '94:de:80:69:dc:01' => 'foo02',
+      '50:e5:49:2f:75:c6' => 'foo03',
+    }

--- a/cookbooks/fb_ethers/attributes/default.rb
+++ b/cookbooks/fb_ethers/attributes/default.rb
@@ -1,0 +1,13 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+default['fb_ethers'] = {
+  'entries' => {},
+}

--- a/cookbooks/fb_ethers/metadata.rb
+++ b/cookbooks/fb_ethers/metadata.rb
@@ -1,0 +1,9 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'fb_ethers'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'BSD'
+description 'Installs/Configures /etc/ethers'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.0.1'

--- a/cookbooks/fb_ethers/recipes/default.rb
+++ b/cookbooks/fb_ethers/recipes/default.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: fb_ethers
+# Recipe:: default
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+template '/etc/ethers' do
+  source 'ethers.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end

--- a/cookbooks/fb_ethers/templates/default/ethers.erb
+++ b/cookbooks/fb_ethers/templates/default/ethers.erb
@@ -1,0 +1,6 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_ethers/README.md
+
+<% node['fb_ethers']['entries'].to_hash.each do |hwaddr, ipaddr| -%>
+<%=  hwaddr %> <%= ipaddr %>
+<% end -%>

--- a/cookbooks/fb_init_sample/metadata.rb
+++ b/cookbooks/fb_init_sample/metadata.rb
@@ -10,6 +10,7 @@ version '0.0.1'
 %w{
   fb_apt
   fb_cron
+  fb_ethers
   fb_fstab
   fb_helpers
   fb_hostconf

--- a/cookbooks/fb_init_sample/recipes/default.rb
+++ b/cookbooks/fb_init_sample/recipes/default.rb
@@ -20,6 +20,7 @@ end
 include_recipe 'fb_modprobe'
 include_recipe 'fb_securetty'
 include_recipe 'fb_hosts'
+include_recipe 'fb_ethers'
 # HERE: resolv
 include_recipe 'fb_limits'
 include_recipe 'fb_hostconf'


### PR DESCRIPTION
This adds a cookbook to manage dnsmasq using the attribute-driven API. It's a rework of an unpublished cookbook I've been running at home for a while. Tested only on Debian, but it should work fine on other distros as there's nothing Debian-specific in it.