### PR TITLE
add fb_p910nd cookbook

### DIFF
--- a/fb_p910nd/README.md
+++ b/fb_p910nd/README.md
@@ -1,0 +1,24 @@
+fb_p910d Cookbook
+====================
+This cookbook installs and configures p910nd, a lightweight print server.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_p910nd']['number']
+* node['fb_p910nd']['device']
+* node['fb_p910nd']['bidirectional']
+* node['fb_p910nd']['listen']
+
+Usage
+-----
+Include `fb_p910nd` in your runlist to install p910nd and enable its service. By
+default it will serve the printer at `/dev/usb/lp0`, which can be customized with
+`node['fb_p910nd']['device']`, and assume it supports bidirectional printing, 
+unless `node['fb_p910nd']['bidirectional']` is set to `false`. The daemon will
+listen on all interfaces, unless `node['fb_p910nd']['listen']` is set to bind it
+to a specific address. The listening port is always `910x`, where `x` is 
+determined by `node['fb_p910nd']['number']`; this defaults to `0`, which means the
+default listening port will be `9100`.

--- a/fb_p910nd/attributes/default.rb
+++ b/fb_p910nd/attributes/default.rb
@@ -1,0 +1,16 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+default['fb_p910nd'] = {
+  'number' => 0,
+  'device' => '/dev/usb/lp0',
+  'bidirectional' => true,
+  'listen' => '',
+}

--- a/fb_p910nd/metadata.rb
+++ b/fb_p910nd/metadata.rb
@@ -1,0 +1,9 @@
+name 'fb_p910nd'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'BSD'
+description 'Installs/Configures fb_p910nd'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+depends 'fb_helpers'

--- a/fb_p910nd/recipes/default.rb
+++ b/fb_p910nd/recipes/default.rb
@@ -1,0 +1,31 @@
+#
+# Cookbook Name:: fb_p910nd
+# Recipe:: default
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+unless node.debian? || node.ubuntu?
+  fail 'fb_p910nd is only supported on Debian and Ubuntu.'
+end
+
+package 'p910nd' do
+  action :upgrade
+end
+
+template '/etc/default/p910nd' do
+  source 'p910nd.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[p910nd]'
+end
+
+service 'p910nd' do
+  action [:enable, :start]
+end

--- a/fb_p910nd/templates/default/p910nd.erb
+++ b/fb_p910nd/templates/default/p910nd.erb
@@ -1,0 +1,10 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_p910nd/README.md
+
+<% conf = node['fb_p910nd'].to_hash
+   options = ["-f #{conf['device']}"]
+   options << '-b' if conf['bidirectional']
+   options << "-i #{conf['listen']}" if conf['listen'] -%>
+P910ND_NUM="<%= conf['number'] %>"
+P910ND_OPTS="<%= options.join(' ') %>"
+P910ND_START=1


### PR DESCRIPTION
This adds a cookbook to manage p910nd using the attribute-driven API. It's a rework of an unpublished cookbook I've been running at home for a while. Tested only on Debian, but it should work fine on Ubuntu too as the package there is exactly the same.