### PR TITLE
add fb_hddtemp cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,11 +8,15 @@ platforms:
       provision_command:
         # remove bogus entry to make fb_fstab happy
         - sed -i '/UUID=/d' /etc/fstab
+	# enable EPEL (for stuff like hddtemp)
+	- rpm -Uvh http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
   - name: centos-7
     driver_config:
       provision_command:
         # remove bogus entry to make fb_fstab happy
         - sed -i '/UUID=/d' /etc/fstab
+	# enable EPEL (for stuff like hddtemp)
+	- rpm -Uvh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm
       run_command: /usr/sbin/init
   - name: ubuntu-14.04
   - name: ubuntu-16.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,15 +8,15 @@ platforms:
       provision_command:
         # remove bogus entry to make fb_fstab happy
         - sed -i '/UUID=/d' /etc/fstab
-	# enable EPEL (for stuff like hddtemp)
-	- rpm -Uvh http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+        # enable EPEL (for stuff like hddtemp)
+        - rpm -Uvh http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
   - name: centos-7
     driver_config:
       provision_command:
         # remove bogus entry to make fb_fstab happy
         - sed -i '/UUID=/d' /etc/fstab
-	# enable EPEL (for stuff like hddtemp)
-	- rpm -Uvh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm
+        # enable EPEL (for stuff like hddtemp)
+        - rpm -Uvh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm
       run_command: /usr/sbin/init
   - name: ubuntu-14.04
   - name: ubuntu-16.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,3 +37,4 @@ suites:
     run_list:
       - recipe[fb_init_sample]
       - recipe[fb_dnsmasq]
+      - recipe[fb_hddtemp]

--- a/cookbooks/fb_hddtemp/README.md
+++ b/cookbooks/fb_hddtemp/README.md
@@ -1,0 +1,21 @@
+fb_hddtemp Cookbook
+====================
+The `fb_hddtemp` cookbook installs and configures hddtemp, an hard drive
+temperature monitoring utility.
+
+Requirements
+------------
+This cookbook requires CentOS, Debian or Ubuntu.
+
+Attributes
+----------
+* node['fb_hddtemp']['enable']
+* node['fb_hddtemp']['sysconfig']
+
+Usage
+-----
+To install hddtemp include `fb_hddtemp`. Settings can be customized using the
+`node['fb_hddtemp']['sysconfig']` attribute, please refer to the
+[attributes file](attributes/default.rb) for the defaults, which attempt to
+match upstreams distro default settings. The daemon is disabled by default, to
+start it set `node['fb_hddtemp']['enable']` to true.

--- a/cookbooks/fb_hddtemp/attributes/default.rb
+++ b/cookbooks/fb_hddtemp/attributes/default.rb
@@ -1,0 +1,34 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+if node.debian? || node.ubuntu?
+  sysconfig = {
+    'run_daemon' => false,
+    'disks' => '',
+    'disks_noprobe' => '',
+    'interface' => '127.0.0.1',
+    'port' => 7634,
+    'database' => '/etc/hddtemp.db',
+    'separator' => '|',
+    'run_syslog' => 0,
+    'options' => '',
+  }
+elsif node.centos?
+  sysconfig = {
+    'hddtemp_options' => '-l 127.0.0.1',
+  }
+else
+  sysconfig = {}
+end
+
+default['fb_hddtemp'] = {
+  'enable' => false,
+  'sysconfig' => sysconfig,
+}

--- a/cookbooks/fb_hddtemp/metadata.rb
+++ b/cookbooks/fb_hddtemp/metadata.rb
@@ -1,0 +1,9 @@
+name 'fb_hddtemp'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'BSD'
+description 'Installs/Configures hddtemp'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+depends 'fb_helpers'

--- a/cookbooks/fb_hddtemp/recipes/default.rb
+++ b/cookbooks/fb_hddtemp/recipes/default.rb
@@ -1,0 +1,43 @@
+#
+# Cookbook Name:: fb_hddtemp
+# Recipe:: default
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+unless node.debian? || node.ubuntu? || node.centos?
+  fail 'fb_hddtemp only supports Debian, Ubuntu and CentOS.'
+end
+
+package 'hddtemp' do
+  action :upgrade
+end
+
+if node.centos?
+  sysconfig = '/etc/sysconfig'
+else
+  sysconfig = '/etc/default'
+end
+
+template "#{sysconfig}/hddtemp" do
+  source 'hddtemp.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[hddtemp]'
+end
+
+service 'hddtemp' do
+  only_if { node['fb_hddtemp']['enable'] }
+  action [:enable, :start]
+end
+
+service 'disable hddtemp' do
+  not_if { node['fb_hddtemp']['enable'] }
+  action [:stop, :disable]
+end

--- a/cookbooks/fb_hddtemp/templates/default/hddtemp.erb
+++ b/cookbooks/fb_hddtemp/templates/default/hddtemp.erb
@@ -1,0 +1,14 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_hddtemp/README.md
+
+<%
+  # If disks is empty it will prevent the daemon from starting; delete it so
+  # it will autoprobe instead.
+  config = node['fb_hddtemp'].to_hash
+  if config['disks'] && config['disks'].empty?
+    config.delete('disks')
+  end
+-%>
+<% config.each do |key, val| -%>
+<%=  key.upcase %>="<%= val %>"
+<% end -%>


### PR DESCRIPTION
This adds a cookbook to manage hddtemp using the attribute-driven API. It's a rework of an unpublished cookbook I've been running at home for a while. Tested only on Debian, but it should work fine on Ubuntu too as the package there is exactly the same.