### PR TITLE
add fb_apcupsd cookbook

### DIFF
--- a/cookbooks/fb_apcupsd/README.md
+++ b/cookbooks/fb_apcupsd/README.md
@@ -1,0 +1,40 @@
+fb_apcupsd Cookbook
+====================
+This cookbook installs and configures apcupsd, the APC UPS Power Management
+daemon and its web interface.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_apcupsd']['config']
+* node['fb_apcupsd']['enable']
+* node['fb_apcupsd']['hosts']
+
+Usage
+-----
+### Daemon
+Include `fb_apcupsd::default` to install apcupsd. The daemon is enabled and 
+started by default; this can be controlled with `node['fb_apcupsd']['enable']`.
+The daemon is configured via the `node['fb_apcupsd']['config']` attribute, 
+which will be used to render the main configuration file at 
+`/etc/apcupsd/apcupsd.conf`. Please refer to the 
+[upstream documentation](http://www.apcupsd.org/manual/manual.html#configuration-directive-reference) 
+for the available options. The default configuration mimics the upstream Debian
+ settings and is listed in the [attributes file](attributes/default.rb). This 
+configuration will autodetect any USB-connected UPS devices and monitor them; 
+it will also activate the network management service on port `3551` and bind it
+to `localhost`.
+
+### Frontend
+Include `fb_apcupsd::frontend` to install the acpupsd web interface. This is 
+composed of a number of CGI programs (multimon, upsaccess, upsstats, upsfstats,
+ upsimage), that can monitor a number of different local and remote UPS devices.
+To this end, use the `node['fb_apcupsd']['hosts']` to define what should be 
+monitored; this defaults to `localhost`. Example:
+
+    node.default['fb_apcupsd']['hosts']['192.168.0.1'] = 'Web server UPS'
+
+Note that this recipe will not install or configure a web server, so unless you
+set one up the CGI will not actually be available.

--- a/cookbooks/fb_apcupsd/attributes/default.rb
+++ b/cookbooks/fb_apcupsd/attributes/default.rb
@@ -1,0 +1,50 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+default['fb_apcupsd'] = {
+  'enable' => true,
+  'config' => {
+    # General options
+    'upsname' => node['hostname'],
+    'upscable' => 'usb',
+    'upstype' => 'usb',
+    'device' => '',
+    'lockfile' => '/var/lock',
+    'scriptdir' => '/etc/apcupsd',
+    'pwrfaildir' => '/etc/apcupsd',
+    'nologindir' => '/etc',
+    # Power failure options
+    'onbatterydelay' => 6,
+    'batterylevel' => 5,
+    'minutes' => 3,
+    'timeout' => 0,
+    'annoy' => 300,
+    'annoydelay' => 60,
+    'nologon' => 'disable',
+    'killdelay' => 0,
+    # Network Information Server
+    'netserver' => 'on',
+    'nisip' => '127.0.0.1',
+    'nisport' => 3551,
+    'eventsfile' => '/var/log/apcupsd.events',
+    'eventsfilemax' => 10,
+    # APC ShareUPS settings
+    'upsclass' => 'standalone',
+    'upsmode' => 'disable',
+    # Logging
+    'stattime' => 0,
+    'statfile' => '/var/log/apcupsd.status',
+    'logstats' => 'off',
+    'datatime' => 0,
+  },
+  'hosts' => {
+    '127.0.0.1' => node['hostname'],
+  },
+}

--- a/cookbooks/fb_apcupsd/files/default/apcupsd
+++ b/cookbooks/fb_apcupsd/files/default/apcupsd
@@ -1,0 +1,8 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_apcupsd/README.md
+
+# Defaults for apcupsd initscript
+
+# Apcupsd-devel internal configuration
+APCACCESS=/sbin/apcaccess
+ISCONFIGURED=yes

--- a/cookbooks/fb_apcupsd/metadata.rb
+++ b/cookbooks/fb_apcupsd/metadata.rb
@@ -1,0 +1,9 @@
+name 'fb_apcupsd'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'BSD'
+description 'Installs/Configures apcupsd'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+depends 'fb_helpers'

--- a/cookbooks/fb_apcupsd/recipes/default.rb
+++ b/cookbooks/fb_apcupsd/recipes/default.rb
@@ -1,0 +1,49 @@
+#
+# Cookbook Name:: fb_apcupsd
+# Recipe:: default
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+unless node.debian? || node.ubuntu? || node.centos?
+  fail 'fb_apcupsd is only supported on Debian, Ubuntu or CentOS.'
+end
+
+package 'apcupsd' do
+  action :upgrade
+end
+
+# this isn't a template as there's nothing really useful to configure in it
+cookbook_file '/etc/default/apcupsd' do
+  only_if { node.debian? || node.ubuntu? }
+  source 'apcupsd'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[apcupsd]'
+end
+
+template '/etc/apcupsd/apcupsd.conf' do
+  source 'apcupsd.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[apcupsd]'
+end
+
+service 'apcupsd' do
+  only_if { node['fb_apcupsd']['enable'] }
+  action [:enable, :start]
+end
+
+service 'disable apcupsd' do
+  not_if { node['fb_apcupsd']['enable'] }
+  action [:stop, :disable]
+end

--- a/cookbooks/fb_apcupsd/recipes/frontend.rb
+++ b/cookbooks/fb_apcupsd/recipes/frontend.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: fb_apcupsd
+# Recipe:: frontend
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+package 'apcupsd-cgi' do
+  action :upgrade
+end
+
+template '/etc/apcupsd/hosts.conf' do
+  source 'hosts.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end

--- a/cookbooks/fb_apcupsd/templates/default/apcupsd.conf.erb
+++ b/cookbooks/fb_apcupsd/templates/default/apcupsd.conf.erb
@@ -1,0 +1,8 @@
+## apcupsd.conf v1.1 ##
+#
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_apcupsd/README.md
+
+<% node['fb_apcupsd']['config'].to_hash.sort.each do |key, val| -%>
+<%=  key.upcase %> <%= val %>
+<% end -%>

--- a/cookbooks/fb_apcupsd/templates/default/hosts.conf.erb
+++ b/cookbooks/fb_apcupsd/templates/default/hosts.conf.erb
@@ -1,0 +1,6 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_apcupsd/README.md
+
+<% node['fb_apcupsd']['hosts'].to_hash.each do |address, description| -%>
+MONITOR <%= address %> "<%= description %>"
+<% end -%>


### PR DESCRIPTION
This adds a cookbook to manage apcupsd using the attribute-driven API. It's a rework of an unpublished cookbook I've been running at home for a while. Tested only on Debian.