### PR TITLE
add fb_zfs cookbook

### DIFF
--- a/cookbooks/fb_zfs/README.md
+++ b/cookbooks/fb_zfs/README.md
@@ -1,0 +1,31 @@
+fb_zfs Cookbook
+====================
+This cookbook installs and configures support for the ZFS filesystem.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_zfs']['enable_zed']
+* node['fb_zfs']['import_on_boot']
+* node['fb_zfs']['mount_on_boot']
+* node['fb_zfs']['share_on_boot']
+
+Usage
+-----
+Include `fb_zfs::zfsonlinux_repo` to enable the
+[ZFS on Linux](http://zfsonlinux.org/debian.html) package repository. This is
+provided as a separate recipe in case you prefer to mirror the packages locally
+or use a different repository. Note that this repo only provides amd64 packages
+for Debian Wheezy and Debian Jessie.
+
+Include `fb_zfs::default` to install and configure ZFS. This will install the 
+necessary packages, which in turn will compile and load the ZFS kernel modules.
+Note that this requires you to have kernel headers and a compiler available 
+(this recipe assumes that's already the case). By default we enable importing 
+and automounting of ZFS filesystems on boot and disable network sharing. 
+This can be controlled via the `node['fb_zfs']['import_on_boot']`, 
+`node['fb_zfs']['mount_on_boot']` and `node['fb_zfs']['share_on_boot']`
+attributes. We also enable the ZED daemon by default, which can be disabled 
+with `node['fb_zfs']['enable_zed']`.

--- a/cookbooks/fb_zfs/attributes/default.rb
+++ b/cookbooks/fb_zfs/attributes/default.rb
@@ -1,0 +1,16 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+default['fb_zfs'] = {
+  'enable_zed' => true,
+  'import_on_boot' => true,
+  'mount_on_boot' => true,
+  'share_on_boot' => false,
+}

--- a/cookbooks/fb_zfs/metadata.rb
+++ b/cookbooks/fb_zfs/metadata.rb
@@ -1,0 +1,9 @@
+name 'fb_zfs'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'BSD'
+description 'Installs/Configures fb_zfs'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+depends 'fb_helpers'

--- a/cookbooks/fb_zfs/metadata.rb
+++ b/cookbooks/fb_zfs/metadata.rb
@@ -2,7 +2,7 @@ name 'fb_zfs'
 maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'BSD'
-description 'Installs/Configures fb_zfs'
+description 'Installs/Configures zfs'
 source_url 'https://github.com/facebook/chef-cookbooks/'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'

--- a/cookbooks/fb_zfs/recipes/default.rb
+++ b/cookbooks/fb_zfs/recipes/default.rb
@@ -1,0 +1,67 @@
+#
+# Cookbook Name:: fb_zfs
+# Recipe:: default
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+package 'zfs packages' do
+  package_name %w{spl spl-dkms zfs-dkms zfsutils}
+  action :upgrade
+end
+
+import_services = []
+if node.systemd?
+  import_services += %w{zfs-import-cache zfs-import-scan}
+else
+  import_services << 'zfs-import'
+end
+
+import_services.each do |svc|
+  service svc do
+    only_if { node['fb_zfs']['import_on_boot'] }
+    action :enable
+  end
+
+  service "disable #{svc}" do
+    not_if { node['fb_zfs']['import_on_boot'] }
+    action :disable
+  end
+end
+
+service 'zfs-zed' do
+  only_if { node['fb_zfs']['enable_zed'] }
+  action [:enable, :start]
+end
+
+service 'disable zfs-zed' do
+  not_if { node['fb_zfs']['enable_zed'] }
+  action [:stop, :disable]
+end
+
+service 'zfs-mount' do
+  only_if { node['fb_zfs']['mount_on_boot'] }
+  action :enable
+end
+
+service 'disable zfs-mount' do
+  not_if { node['fb_zfs']['mount_on_boot'] }
+  action :disable
+end
+
+service 'zfs-share' do
+  only_if { node['fb_zfs']['share_on_boot'] }
+  action :enable
+end
+
+service 'disable zfs-share' do
+  not_if { node['fb_zfs']['share_on_boot'] }
+  action :disable
+end

--- a/cookbooks/fb_zfs/recipes/zfsonlinux_repo.rb
+++ b/cookbooks/fb_zfs/recipes/zfsonlinux_repo.rb
@@ -1,0 +1,26 @@
+#
+# Cookbook Name:: fb_zfs
+# Recipe:: zfsonlinux_repo
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+unless node['kernel']['machine'] == 'x86_64'
+  fail 'fb_zfs is only supported on x86_64 hosts.'
+end
+
+distro = node['lsb']['codename']
+unless distro == 'wheezy' || distro == 'jessie'
+  fail 'fb_zfs is only supported on Debian Wheezy and Debian Jessie'
+end
+
+node.default['fb_apt']['repos'] <<
+  "deb [arch=amd64] http://archive.zfsonlinux.org/debian #{distro} main"
+node.default['fb_apt']['keys']['4D5843EA'] = nil

--- a/cookbooks/fb_zfs/recipes/zfsonlinux_repo.rb
+++ b/cookbooks/fb_zfs/recipes/zfsonlinux_repo.rb
@@ -17,7 +17,7 @@ unless node['kernel']['machine'] == 'x86_64'
 end
 
 distro = node['lsb']['codename']
-unless distro == 'wheezy' || distro == 'jessie'
+unless ['wheezy', 'jessie'].include?(distro)
   fail 'fb_zfs is only supported on Debian Wheezy and Debian Jessie'
 end
 


### PR DESCRIPTION
This adds a cookbook to manage ZFS using the attribute-driven API. It's a rework of an unpublished cookbook I've been running at home for a while. Tested only on Debian.