### PR TITLE
add test kitchen integration to travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.orig
 *.rej
 Gemfile.lock
+.kitchen

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,37 @@
+driver:
+  name: docker
+  privileged: true
+
+platforms:
+  - name: centos-6
+    driver_config:
+      provision_command:
+        # remove bogus entry to make fb_fstab happy
+        - sed -i '/UUID=/d' /etc/fstab
+  - name: centos-7
+    driver_config:
+      provision_command:
+        # remove bogus entry to make fb_fstab happy
+        - sed -i '/UUID=/d' /etc/fstab
+      run_command: /usr/sbin/init
+  - name: ubuntu-14.04
+  - name: ubuntu-16.04
+    driver_config:
+      run_command: /sbin/init
+  - name: debian-8
+    driver_config:
+      provision_command:
+        # https://github.com/test-kitchen/test-kitchen/issues/1018
+        # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=814070
+        - apt-get install -y wget
+      run_command: /sbin/init
+  - name: debian-sid
+    driver_config:
+      run_command: /sbin/init
+
+provisioner:
+  name: chef_zero
+
+suites:
+  - name: default
+    run_list: recipe[fb_init_sample]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,36 @@
 language: ruby
-sudo: false
+sudo: required
+services: docker
+env:
+  matrix:
+    - INSTANCE=default-centos-6
+    - INSTANCE=default-centos-7
+    - INSTANCE=default-ubuntu-1404
+    - INSTANCE=default-ubuntu-1604
+    - INSTANCE=default-debian-8
+    - INSTANCE=default-debian-sid
+
+matrix:
+  allow_failures:
+    - env: INSTANCE=default-debian-sid
+
 rvm:
-  - 2.0.0
-  - 2.2.0
+  # 2.1.0 is not supported anymore by chef-zero
+  # 2.2.0 fails due to https://github.com/flori/json/issues/253
+  - 2.2.2
+  - 2.3.0
+
 gemfile:
   Gemfile
+
+before_script:
+  # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142455888
+  - sudo iptables -L DOCKER || sudo iptables -N DOCKER
+  # hack to make kitchen happy
+  - mkdir -p cookbooks && cp -a fb_* cookbooks/
+
 script:
   - bundle exec rspec --format=d --color */spec/*rb
   - bundle exec rubocop --display-cop-names -c .rubocop.yml
   - ./run_foodcritic
+  - bundle exec kitchen verify $INSTANCE

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ source 'https://rubygems.org'
   chef
   foodcritic
   rubocop
+  test-kitchen
+  kitchen-docker
 }.each do |g|
   gem g
 end

--- a/fb_init_sample/metadata.rb
+++ b/fb_init_sample/metadata.rb
@@ -1,5 +1,5 @@
 # vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
-name 'fb_init_init'
+name 'fb_init_sample'
 maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
 license 'Apache 2.0'
@@ -8,6 +8,7 @@ source_url 'https://github.com/facebook/chef-cookbooks/'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.0.1'
 %w{
+  fb_apt
   fb_cron
   fb_fstab
   fb_helpers

--- a/fb_init_sample/recipes/default.rb
+++ b/fb_init_sample/recipes/default.rb
@@ -9,8 +9,13 @@
 include_recipe 'fb_init_sample::site_settings'
 
 # HERE: yum
+if node.debian? || node.ubuntu?
+  include_recipe 'fb_apt'
+end
 # HERE: chef_client
-include_recipe 'fb_systemd'
+if node.systemd?
+  include_recipe 'fb_systemd'
+end
 # HERE: ssh
 include_recipe 'fb_modprobe'
 include_recipe 'fb_securetty'


### PR DESCRIPTION
This adds convergence integration tests on Ubuntu 14.04, CentOS 7 and Debian 8 using test-kitchen. It's based on the approach described in https://github.com/zuazo/kitchen-in-travis-native. 