### PR TITLE
add fb_nsswitch cookbook

### DIFF
--- a/cookbooks/fb_init_sample/metadata.rb
+++ b/cookbooks/fb_init_sample/metadata.rb
@@ -19,6 +19,7 @@ version '0.0.1'
   fb_logrotate
   fb_modprobe
   fb_motd
+  fb_nsswitch
   fb_swap
   fb_securetty
   fb_sysctl

--- a/cookbooks/fb_init_sample/recipes/default.rb
+++ b/cookbooks/fb_init_sample/recipes/default.rb
@@ -16,6 +16,7 @@ end
 if node.systemd?
   include_recipe 'fb_systemd'
 end
+include_recipe 'fb_nsswitch'
 # HERE: ssh
 include_recipe 'fb_modprobe'
 include_recipe 'fb_securetty'

--- a/cookbooks/fb_nsswitch/README.md
+++ b/cookbooks/fb_nsswitch/README.md
@@ -1,0 +1,22 @@
+fb_nsswitch Cookbook
+====================
+This cookbook configures `/etc/nsswitch.conf` and provides an API for modifying
+all aspects of the `/etc/nsswitch.conf` file.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_nsswitch']['databases']
+
+Usage
+-----
+By default we set every database to use `files` as their source, except `hosts`
+which will default to `files dns`. Database mappings can be set with the
+`node['fb_nsswitch']['databases']`. attribute. Example:
+
+    node.default['fb_nsswitch']['databases']['passwd'] = [
+      'files',
+      'ldap',
+    ]

--- a/cookbooks/fb_nsswitch/attributes/default.rb
+++ b/cookbooks/fb_nsswitch/attributes/default.rb
@@ -1,0 +1,37 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+databases = {}
+
+%w{
+  aliases
+  automount
+  ethers
+  group
+  hosts
+  initgroups
+  netgroup
+  netmasks
+  networks
+  passwd
+  protocols
+  publickey
+  rpc
+  services
+  shadow
+}.each do |db|
+  databases[db] = ['files']
+end
+
+databases['hosts'] << 'dns'
+
+default['fb_nsswitch'] = {
+  'databases' => databases,
+}

--- a/cookbooks/fb_nsswitch/metadata.rb
+++ b/cookbooks/fb_nsswitch/metadata.rb
@@ -1,0 +1,9 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'fb_nsswitch'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'BSD'
+description 'Installs/Configures /etc/nsswitch.conf'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.0.1'

--- a/cookbooks/fb_nsswitch/recipes/default.rb
+++ b/cookbooks/fb_nsswitch/recipes/default.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: fb_nsswitch
+# Recipe:: default
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+template '/etc/nsswitch.conf' do
+  source 'nsswitch.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end

--- a/cookbooks/fb_nsswitch/templates/default/nsswitch.conf.erb
+++ b/cookbooks/fb_nsswitch/templates/default/nsswitch.conf.erb
@@ -1,0 +1,6 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_nsswitch/README.md
+
+<% node['fb_nsswitch']['databases'].to_hash.each do |db, sources| -%>
+<%=  db %>: <%= sources.join(' ') %>
+<% end -%>


### PR DESCRIPTION
This adds a simple cookbook to manage `/etc/nsswitch.conf` using the attribute-driven API.