### PR TITLE
add fb_collectd cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -41,6 +41,7 @@ suites:
     run_list:
       - recipe[fb_init_sample]
       - recipe[fb_apcupsd]
+      - recipe[fb_collectd]
       - recipe[fb_dnsmasq]
       - recipe[fb_hddtemp]
       - recipe[fb_vsftpd]

--- a/cookbooks/fb_collectd/README.md
+++ b/cookbooks/fb_collectd/README.md
@@ -1,0 +1,41 @@
+fb_collectd Cookbook
+====================
+The `fb_collectd` cookbook installs and configures collectd, a statistics
+collection and monitoring daemon.
+
+Requirements
+------------
+This cookbook requires CentOS, Debian or Ubuntu.
+
+Attributes
+----------
+* node['fb_collectd']['collection']
+* node['fb_collectd']['globals']
+* node['fb_collectd']['plugins']
+* node['fb_collectd']['sysconfig']
+
+Usage
+-----
+### Daemon
+To install collectd include `fb_collectd::default`. Global settings can be
+customized using the `node['fb_collectd']['globals']` attribute and individual
+plugins can be enabled and configured using `node['fb_collectd']['plugins']`.
+Example:
+
+```ruby
+node.default['fb_collectd']['global']['FQDNLookup'] = true
+node.default['fb_collectd']['plugins']['cpu'] = nil
+node.default['fb_collectd']['plugins']['syslog'] = {
+  'LogLevel' => 'info',
+}
+```
+
+On Debian systems, environment settings can be configured in 
+`node['fb_collectd']['sysconfig']`; note that this attribute is ignored on
+CentOS.
+
+### Frontend
+The collectd-web fronted can be installed with the `fb_collectd::fronted`
+recipe. Use the `node['fb_collectd']['collection']` to customize its settings.
+Note that this recipe will not install or configure a web server, so unless you
+set one up the collection CGIs will not actually be available.

--- a/cookbooks/fb_collectd/attributes/default.rb
+++ b/cookbooks/fb_collectd/attributes/default.rb
@@ -1,0 +1,24 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+default['fb_collectd'] = {
+  'collection' => {
+    'datadir' => '/var/lib/collectd/rrd/',
+    'libdir' => '/usr/lib/collectd/',
+  },
+  'globals' => {},
+  'plugins' => {},
+  'sysconfig' => {
+    'disable' => false,
+    'use_collectdmon' => true,
+    'maxwait' => 30,
+    'enable_corefiles' => false,
+  },
+}

--- a/cookbooks/fb_collectd/libraries/default.rb
+++ b/cookbooks/fb_collectd/libraries/default.rb
@@ -1,0 +1,50 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+module FB
+  # collectd utility functions
+  class Collectd
+    # Internal helper function to generate /etc/collectd/collectd.conf entries
+    def self._gen_collectd_conf_entry(k, v, i = 0)
+      indent = ' ' * i
+      # For keys with multiple values (i.e. an array for a value) we need to
+      # specify the whole line multiple times, so we generate:
+      #   key = "foo1"
+      #   key = "foo2"
+      # and so on.
+      if v.is_a?(Array)
+        s = ''
+        v.each do |vv|
+          s += self._gen_collectd_conf_entry(k, vv, i) + "\n"
+        end
+        return s.chop
+      # Hashes are represented with Apache vhost-like configs. The key name
+      # will start the block, and everything inside of it is processed like
+      # normal (further hashes, arrays, etc. will all be processed properly)
+      # and then we close the block.
+      elsif v.is_a?(Hash)
+        s = "#{indent}<#{k}>\n"
+        v.each do |kk, vv|
+          s += self._gen_collectd_conf_entry(kk, vv, i + 2) + "\n"
+        end
+        s += "#{indent}</#{k.split(' ')[0]}>"
+        return s
+      elsif v.is_a?(TrueClass)
+        return "#{indent}#{k} true"
+      elsif v.is_a?(FalseClass)
+        return "#{indent}#{k} false"
+      elsif v.is_a?(Numeric)
+        return "#{indent}#{k} #{v}"
+      else
+        return "#{indent}#{k} \"#{v}\""
+      end
+    end
+  end
+end

--- a/cookbooks/fb_collectd/metadata.rb
+++ b/cookbooks/fb_collectd/metadata.rb
@@ -1,0 +1,9 @@
+name 'fb_collectd'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'BSD'
+description 'Installs/Configures collectd'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+depends 'fb_helpers'

--- a/cookbooks/fb_collectd/recipes/default.rb
+++ b/cookbooks/fb_collectd/recipes/default.rb
@@ -1,0 +1,62 @@
+#
+# Cookbook Name:: fb_collectd
+# Recipe:: default
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+unless node.centos? || node.debian? || node.ubuntu?
+  fail 'fb_collectd is only supported on CentOS, Debian or Ubuntu.'
+end
+
+case node['platform_family']
+when 'rhel', 'fedora'
+  pkg = 'collectd'
+  conf = '/etc/collectd.conf'
+  conf_d = '/etc/collectd.d'
+when 'debian'
+  pkg = 'collectd-core'
+  conf = '/etc/collectd/collectd.conf'
+  conf_d = '/etc/collectd/collectd.conf.d'
+end
+
+package pkg do
+  action :upgrade
+end
+
+template '/etc/default/collectd' do
+  only_if { node['platform_family'] == 'debian' }
+  source 'collectd.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[collectd]'
+end
+
+Dir.glob("#{conf_d}/*").each do |f|
+  file f do
+    action :delete
+  end
+end
+
+template conf do
+  source 'collectd.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[collectd]'
+end
+
+service 'collectd' do
+  # do not start with an empty config
+  not_if do
+    node['fb_collectd']['globals'].empty? &&
+      node['fb_collectd']['plugins'].empty?
+  end
+  action [:enable, :start]
+end

--- a/cookbooks/fb_collectd/recipes/frontend.rb
+++ b/cookbooks/fb_collectd/recipes/frontend.rb
@@ -1,0 +1,35 @@
+#
+# Cookbook Name:: fb_collectd
+# Recipe:: frontend
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+unless node.centos? || node.debian? || node.ubuntu?
+  fail 'fb_collectd is only supported on CentOS, Debian or Ubuntu.'
+end
+
+case node['platform_family']
+when 'rhel', 'fedora'
+  conf = '/etc/collectd/collection.conf'
+when 'debian'
+  conf = '/etc/collection.conf'
+end
+
+package 'collectd-web' do
+  # this is bundled in the main collectd-core package on debian
+  not_if { node['platform_family'] == 'debian' }
+  action :upgrade
+end
+
+template conf do
+  source 'collection.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end

--- a/cookbooks/fb_collectd/templates/default/collectd.conf.erb
+++ b/cookbooks/fb_collectd/templates/default/collectd.conf.erb
@@ -1,0 +1,18 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_collectd/README.md
+<% config = node['fb_collectd'].to_hash -%>
+
+<% config['globals'].each do |key, val| -%>
+<%=  FB::Collectd._gen_collectd_conf_entry(key, val) %>
+<% end -%>
+
+<% config['plugins'].each do |plugin, config| -%>
+LoadPlugin <%= plugin %>
+<%   if config -%>
+<Plugin <%= plugin %>>
+<%     config.each do |key, val| -%>
+<%=      FB::Collectd._gen_collectd_conf_entry(key, val, 2) %>
+<%     end -%>
+</Plugin>
+<%   end -%>
+<% end -%>

--- a/cookbooks/fb_collectd/templates/default/collectd.erb
+++ b/cookbooks/fb_collectd/templates/default/collectd.erb
@@ -1,0 +1,13 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_collectd/README.md
+
+<% node['fb_collectd']['sysconfig'].to_hash.each do |key, val|
+     if val.is_a?(TrueClass)
+       v = 1
+     elsif val.is_a?(FalseClass)
+       v = 0
+     else
+       v = val
+     end -%>
+<%=  key.upcase %>=<%= v %>
+<% end -%>

--- a/cookbooks/fb_collectd/templates/default/collection.conf.erb
+++ b/cookbooks/fb_collectd/templates/default/collection.conf.erb
@@ -1,0 +1,6 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_collectd/README.md
+
+<% node['fb_collectd']['collection'].to_hash.each do |key, val| -%>
+<%=  key %>: "<%= val %>"
+<% end -%>


### PR DESCRIPTION
This adds a cookbook to manage collectd using the attribute-driven API. It's a rework of an unpublished cookbook I've been running at home for a while. Tested on Debian and CentOS.