### PR TITLE
add fb_apt_cacher cookbook

### DIFF
--- a/cookbooks/fb_apt_cacher/README.md
+++ b/cookbooks/fb_apt_cacher/README.md
@@ -1,0 +1,32 @@
+fb_apt_cacher Cookbook
+====================
+This cookbook installs and configures Apt-Cacher NG, caching proxy server for
+software repositories.
+
+Requirements
+------------
+Debian
+
+Attributes
+----------
+* node['fb_apt_cacher']['config']
+* node['fb_apt_cacher']['security']
+* node['fb_apt_cacher']['sysconfig']
+
+Usage
+-----
+Include `fb_apt_cacher` in your runlist to install Apt-Cacher NG. Configuration
+can be customized using `node['fb_apt_cacher']['config']` according to the 
+[upstream documentation](https://www.unix-ag.uni-kl.de/~bloch/acng/html/index.html).
+Please refer to the [attributes file](attributes/default.rb) for the default
+settings, which mimic upstream Debian defaults. Additional configuration is
+available via the `node['fb_apt_cacher']['security']` attribute, which will be
+rendered into a separate config file with restricted permissions. This is
+useful to set things like access credentials, for example:
+
+```ruby
+node.default['fb_apt_cacher']['security']['AdminAuth'] = 'admin:secret'
+```
+
+Finally, the startup environment can be customized using the 
+`node['fb_apt_cacher']['sysconfig']` attribute.

--- a/cookbooks/fb_apt_cacher/attributes/default.rb
+++ b/cookbooks/fb_apt_cacher/attributes/default.rb
@@ -1,0 +1,37 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+default['fb_apt_cacher'] = {
+  'config' => {
+    'CacheDir' => '/var/cache/apt-cacher-ng',
+    'LogDir' => '/var/log/apt-cacher-ng',
+    'SupportDir' => '/usr/lib/apt-cacher-ng',
+    'Port' => 3142,
+    'Remap-debrep' => 'file:deb_mirror*.gz /debian ; file:backends_debian',
+    'Remap-uburep' => 'file:ubuntu_mirrors /ubuntu ; file:backends_ubuntu',
+    'Remap-debvol' =>
+      'file:debvol_mirror*.gz /debian-volatile ; file:backends_debvol',
+    'Remap-cygwin' => 'file:cygwin_mirrors /cygwin',
+    'Remap-sfnet' => 'file:sfnet_mirrors',
+    'Remap-alxrep' => 'file:archlx_mirrors /archlinux',
+    'Remap-fedora' => 'file:fedora_mirrors',
+    'Remap-epel' => 'file:epel_mirrors',
+    'Remap-slrep' => 'file:sl_mirrors',
+    'Remap-gentoo' => 'file:gentoo_mirrors.gz /gentoo ; file:backends_gentoo',
+    'ReportPage' => 'acng-report.html',
+    'ExThreshold' => 4,
+    'ConnectProto' => 'v4 v6',
+    'LocalDirs' => 'acng-doc /usr/share/doc/apt-cacher-ng',
+  },
+  'security' => {},
+  'sysconfig' => {
+    'daemon_opts' => '-c /etc/apt-cacher-ng',
+  },
+}

--- a/cookbooks/fb_apt_cacher/metadata.rb
+++ b/cookbooks/fb_apt_cacher/metadata.rb
@@ -1,0 +1,9 @@
+name 'fb_apt_cacher'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'BSD'
+description 'Installs/Configures apt-cacher-ng'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+depends 'fb_helpers'

--- a/cookbooks/fb_apt_cacher/recipes/default.rb
+++ b/cookbooks/fb_apt_cacher/recipes/default.rb
@@ -1,0 +1,64 @@
+#
+# Cookbook Name:: fb_apt_cacher
+# Recipe:: default
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+unless node.debian?
+  fail 'fb_apt_cacher is only supported on Debian.'
+end
+
+package 'apt-cacher-ng' do
+  action :upgrade
+end
+
+%w{CacheDir LogDir}.each do |dir|
+  directory dir do
+    path lazy { node['fb_apt_cacher']['config'][dir] }
+    owner 'apt-cacher-ng'
+    group 'apt-cacher-ng'
+    mode '2755'
+  end
+end
+
+template '/etc/default/apt-cacher-ng' do
+  source 'apt-cacher-ng.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[apt-cacher-ng]'
+end
+
+template '/etc/apt-cacher-ng/acng.conf' do
+  source 'acng.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  variables(
+    :section => 'config',
+  )
+  notifies :restart, 'service[apt-cacher-ng]'
+end
+
+template '/etc/apt-cacher-ng/security.conf' do
+  source 'acng.conf.erb'
+  owner 'apt-cacher-ng'
+  group 'apt-cacher-ng'
+  mode '0600'
+  variables(
+    :section => 'security',
+  )
+  notifies :restart, 'service[apt-cacher-ng]'
+end
+
+service 'apt-cacher-ng' do
+  action [:enable, :start]
+end

--- a/cookbooks/fb_apt_cacher/templates/default/acng.conf.erb
+++ b/cookbooks/fb_apt_cacher/templates/default/acng.conf.erb
@@ -1,0 +1,6 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_apt_cacher/README.md
+
+<% node['fb_apt_cacher'][@section].to_hash.each do |key, val| -%>
+<%=  key %>: <%= val %>
+<% end -%>

--- a/cookbooks/fb_apt_cacher/templates/default/apt-cacher-ng.erb
+++ b/cookbooks/fb_apt_cacher/templates/default/apt-cacher-ng.erb
@@ -1,0 +1,6 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_apt_cacher/README.md
+
+<% node['fb_apt_cacher']['sysconfig'].to_hash.each do |key, val| -%>
+<%=  key.upcase %>=<%= val %>
+<% end -%>


### PR DESCRIPTION
This adds a cookbook to manage Apt-Cacher NG using the attribute-driven API. It's a rework of an unpublished cookbook I've been running at home for a while. Tested on Debian.