### PR TITLE
fix travis

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,7 +19,7 @@ platforms:
         # remove bogus entry to make fb_fstab happy
         - sed -i '/UUID=/d' /etc/fstab
         # enable EPEL (for stuff like hddtemp)
-        - rpm -Uvh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm
+        - rpm -Uvh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-7.noarch.rpm
       run_command: /usr/sbin/init
   - name: ubuntu-14.04
   - name: ubuntu-16.04
@@ -34,7 +34,7 @@ platforms:
       run_command: /sbin/init
   - name: debian-sid
     driver_config:
-      run_command: /sbin/init
+      run_command: /bin/systemd
 
 provisioner:
   name: chef_zero

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -140,3 +140,6 @@ Style/IndentArray:
 
 Style/SignalException:
   EnforcedStyle: semantic
+
+Style/NumericLiteralPrefix:
+  Enabled: false


### PR DESCRIPTION
- update url for c7 epel
- disable new useless robocop rule that causes warnings like

```
Offenses:

cookbooks/fb_fstab/libraries/provider.rb:46:63: C: Style/NumericLiteralPrefix: Use 0o for octal literals.
        FileUtils.mkdir_p(mount_data['mount_point'], :mode => 0755)
                                                              ^^^^
cookbooks/fb_fstab/libraries/default.rb:49:25: C: Style/NumericLiteralPrefix: Use 0o for octal literals.
        FileUtils.chmod(0400, '/root/fstab.before_fb_fstab')
                        ^^^^
cookbooks/fb_fstab/spec/public_spec.rb:792:56: C: Style/NumericLiteralPrefix: Use 0o for octal literals.
                                              :mode => 0755).and_return(true)
                                                       ^^^^
```