### PR TITLE
add fb_vsftpd cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -43,3 +43,4 @@ suites:
       - recipe[fb_apcupsd]
       - recipe[fb_dnsmasq]
       - recipe[fb_hddtemp]
+      - recipe[fb_vsftpd]

--- a/cookbooks/fb_vsftpd/README.md
+++ b/cookbooks/fb_vsftpd/README.md
@@ -1,0 +1,27 @@
+fb_vsftpd Cookbook
+====================
+This cookbook installs and configures vsftpd, the lightweight FTP server.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_vsftpd']['config']
+* node['fb_vsftpd']['enable']
+* node['fb_vsftpd']['ftpusers']
+* node['fb_vsftpd']['user_list']
+
+Usage
+-----
+Include `fb_vsftpd::default` to install vsftpd. The daemon is enabled and 
+started by default; this can be controlled with `node['fb_vsftpd']['enable']`.
+The daemon is configured via the `node['fb_vsftpd']['config']` attribute, 
+which will be used to render the main configuration file `vsftpd.conf`. Please
+refer to the
+[upstream documentation](http://vsftpd.beasts.org/vsftpd_conf.html)
+for the available options. The default configuration mimics the upstream Debian
+settings and is listed in the [attributes file](attributes/default.rb). Use the
+`node['fb_vsftpd']['ftpusers']` to control which users will be denied access at
+PAM stage. Use `node['fb_vsftpd']['user_list']` to populate the vsftpd user
+list, which by default is the same as ftpusers and set to deny mode.

--- a/cookbooks/fb_vsftpd/attributes/default.rb
+++ b/cookbooks/fb_vsftpd/attributes/default.rb
@@ -1,0 +1,50 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+bad_users = %w{
+  root
+  daemon
+  bin
+  sys
+  sync
+  games
+  man
+  lp
+  mail
+  news
+  uucp
+  nobody
+}
+
+if node.centos?
+  bad_users += %w{
+    adm
+    operator
+    shutdown
+    halt
+  }
+end
+
+default['fb_vsftpd'] = {
+  'enable' => true,
+  'config' => {
+    'listen' => true,
+    'anonymous_enable' => true,
+    'dirmessage_enable' => true,
+    'use_localtime' => true,
+    'xferlog_enable' => true,
+    'connect_from_port_20' => true,
+    'secure_chroot_dir' => '/var/run/vsftpd/empty',
+    'pam_service_name' => 'vsftpd',
+    'userlist_enable' => true,
+  },
+  'ftpusers' => bad_users,
+  'user_list' => bad_users,
+}

--- a/cookbooks/fb_vsftpd/metadata.rb
+++ b/cookbooks/fb_vsftpd/metadata.rb
@@ -1,0 +1,9 @@
+name 'fb_vsftpd'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'BSD'
+description 'Installs/Configures vsftpd'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+depends 'fb_helpers'

--- a/cookbooks/fb_vsftpd/recipes/default.rb
+++ b/cookbooks/fb_vsftpd/recipes/default.rb
@@ -1,0 +1,72 @@
+#
+# Cookbook Name:: fb_vsftpd
+# Recipe:: default
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+unless node.centos? || node.debian? || node.ubuntu?
+  fail 'fb_vsftpd is only supported on CentOS, Debian or Ubuntu'
+end
+
+package 'vsftpd' do
+  action :upgrade
+  notifies :restart, 'service[vsftpd]'
+end
+
+prefix = value_for_platform_family(
+  'rhel' => '/etc/vsftpd',
+  'debian' => '/etc',
+)
+
+user_list = value_for_platform_family(
+  'rhel' => "#{prefix}/user_list",
+  'debian' => "#{prefix}/vsftpd.user_list",
+)
+
+template "#{prefix}/vsftpd.conf" do
+  source 'vsftpd.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[vsftpd]'
+end
+
+template "#{prefix}/ftpusers" do
+  source 'ftpusers.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[vsftpd]'
+  variables(
+    :section => 'ftpusers',
+  )
+end
+
+template user_list do
+  source 'ftpusers.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[vsftpd]'
+  variables(
+    :section => 'user_list',
+  )
+end
+
+service 'vsftpd' do
+  only_if { node['fb_vsftpd']['enable'] }
+  action [:enable, :start]
+end
+
+service 'disable vsftpd' do
+  not_if { node['fb_vsftpd']['enable'] }
+  action [:stop, :disable]
+end

--- a/cookbooks/fb_vsftpd/templates/default/ftpusers.erb
+++ b/cookbooks/fb_vsftpd/templates/default/ftpusers.erb
@@ -1,0 +1,6 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_vsftpd/README.md
+
+<% node['fb_vsftpd'][@section].each do |user| -%>
+<%=  user %>
+<% end -%>

--- a/cookbooks/fb_vsftpd/templates/default/vsftpd.conf.erb
+++ b/cookbooks/fb_vsftpd/templates/default/vsftpd.conf.erb
@@ -1,0 +1,12 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_vsftpd/README.md
+
+<% node['fb_vsftpd']['config'].to_hash.each do |key, val| -%>
+<%   if val.kind_of?(TrueClass) -%>
+<%=    key %>=YES
+<%   elsif val.kind_of?(FalseClass) -%>
+<%=    key %>=NO
+<%   else -%>
+<%=    key %>=<%= val.to_s %>
+<%   end -%>
+<% end -%>


### PR DESCRIPTION
This adds a cookbook to manage vsftpd using the attribute-driven API. It's a rework of an unpublished cookbook I've been running at home for a while. Tested on Debian and CentOS.