### PR TITLE
add fb_reprepro cookbook

### DIFF
--- a/cookbooks/fb_reprepro/README.md
+++ b/cookbooks/fb_reprepro/README.md
@@ -1,0 +1,67 @@
+fb_reprepro Cookbook
+====================
+Installs and configures reprepro, a tool to manage a repository of Debian
+packages.
+
+Requirements
+------------
+Currently only tested on Debian and Ubuntu.
+
+Attributes
+----------
+* node['fb_reprepro']['user']
+* node['fb_reprepro']['group']
+* node['fb_reprepro']['distributions'][$NAME]
+* node['fb_reprepro']['updates'][$NAME]
+* node['fb_reprepro']['pulls'][$NAME]
+* node['fb_reprepro']['incoming'][$NAME]
+* node['fb_reprepro']['options'][$KEY][$VAL]
+
+Usage
+-----
+Including `fb_reprepro` will install the `reprepro` package and setup a
+repository tree for the under `node['fb_reprepro']['options']['basedir']`. This
+will be owned by the user/group set in `node['fb_reprepro']['user']` and
+`node['fb_reprepro']['group']`. These default to `root`, but it is recommented
+to create a non-privileged user and update these accordingly. Other general
+reprepro settings can be defined in `node['fb_reprepro']['options']`.
+
+This cookbook does not setup a webserver, you'll have to do that separately if
+you'd like to make the repository available to APT clients.
+
+### Distributions, updates and pulls
+Refer to the
+[upstream documentation](http://mirrorer.alioth.debian.org/reprepro.1.html)
+for details on how to setup distributions, updates and pulls. These are
+controlled by the respective attributes. Example:
+
+```ruby
+node.default['fb_reprepro']['distributions']['jessie'] = {
+  'Codename' => 'jessie'
+  'Architectures' => %w{i386 amd64 source}
+  'Components' => %w{main contrib non-free}
+  'UDebComponents' => 'main'
+  'SignWith' => 'F3EFDBD9'
+  'DebIndices' => %w{Packages Release . .gz .bz2}
+  'UDebIndices' => %w{Packages . .gz .bz2}
+  'DscIndices' => %w{Sources Release .gz .bz2}
+  'Contents' => %w{. .gz .bz2}
+}
+```
+
+### Incoming
+Reprepro supports automatically importing packages from an `incoming` queue.
+This is setup via the `node['fb_reprepro']['incoming']` attribute. Example:
+
+```ruby
+node.default['fb_reprepro']['incoming']['default'] = {
+  'Name' => 'default',
+  'IncomingDir' => 'incoming',
+  'TempDir' => 'tmp',
+  'Allow' => 'jessie',
+  'Cleanup' => 'on_deny on_error',
+}
+```
+
+Note that the actual incoming processing will have to be handled separately,
+e.g. using a cronjob.

--- a/cookbooks/fb_reprepro/attributes/default.rb
+++ b/cookbooks/fb_reprepro/attributes/default.rb
@@ -1,0 +1,22 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+default['fb_reprepro'] = {
+  'user' => 'root',
+  'group' => 'root',
+  'distributions' => {},
+  'updates' => {},
+  'pulls' => {},
+  'incoming' => {},
+  'options' => {
+    'verbose' => nil,
+    'basedir' => '/srv/reprepro',
+  },
+}

--- a/cookbooks/fb_reprepro/metadata.rb
+++ b/cookbooks/fb_reprepro/metadata.rb
@@ -1,0 +1,10 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'fb_reprepro'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'BSD'
+description 'Installs/Configures reprepro'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.0.1'
+depends 'fb_helpers'

--- a/cookbooks/fb_reprepro/recipes/default.rb
+++ b/cookbooks/fb_reprepro/recipes/default.rb
@@ -1,0 +1,89 @@
+#
+# Cookbook Name:: fb_reprepro
+# Recipe:: default
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+unless node
+  fail 'fb_reprepro is only supported on Debian and Ubuntu.'
+end
+
+package 'reprepro' do
+  action :upgrade
+end
+
+directory 'repository' do
+  only_if { node['fb_reprepro']['options']['basedir'] }
+  path lazy { node['fb_reprepro']['options']['basedir'] }
+  owner lazy { node['fb_reprepro']['user'] }
+  group lazy { node['fb_reprepro']['group'] }
+  mode '0644'
+end
+
+directory 'repository/conf' do
+  only_if { node['fb_reprepro']['options']['basedir'] }
+  path lazy { "#{node['fb_reprepro']['options']['basedir']}/conf" }
+  owner lazy { node['fb_reprepro']['user'] }
+  group lazy { node['fb_reprepro']['group'] }
+  mode '0644'
+end
+
+%w{
+  IncomingDir
+  TempDir
+}.each do |dir|
+  directory "repository/#{dir}" do
+    only_if do
+      node['fb_reprepro']['options']['basedir'] &&
+        node['fb_reprepro']['incoming'][dir]
+    end
+    path lazy do
+      "#{node['fb_reprepro']['options']['basedir']}/" +
+        node['fb_reprepro']['incoming'][dir]
+    end
+    owner lazy { node['fb_reprepro']['user'] }
+    group lazy { node['fb_reprepro']['group'] }
+    mode '0644'
+  end
+end
+
+%w{
+  distributions
+  updates
+  pulls
+  incoming
+}.each do |conffile|
+  template "repository/conf/#{conffile}" do
+    only_if do
+      node['fb_reprepro']['options']['basedir'] &&
+        node['fb_reprepro'][conffile]
+    end
+    path lazy do
+      "#{node['fb_reprepro']['options']['basedir']}/conf/#{conffile}"
+    end
+    source 'config.erb'
+    owner 'root'
+    group 'root'
+    mode '0644'
+    variables(
+      :config => conffile,
+    )
+  end
+end
+
+template 'repository/conf/options' do
+  only_if { node['fb_reprepro']['options']['basedir'] }
+  path lazy do
+    "#{node['fb_reprepro']['options']['basedir']}/conf/options"
+  end
+  source 'options.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end

--- a/cookbooks/fb_reprepro/templates/default/config.erb
+++ b/cookbooks/fb_reprepro/templates/default/config.erb
@@ -1,0 +1,6 @@
+<% node['fb_reprepro'][@config].to_hash.each do |_name, config| -%>
+<%   config.each do |key, val| -%>
+<%=    key %>: <%= val.is_a?(Array) ? val.join(' ') : val %>
+<%   end -%>
+
+<% end -%>

--- a/cookbooks/fb_reprepro/templates/default/options.erb
+++ b/cookbooks/fb_reprepro/templates/default/options.erb
@@ -1,0 +1,3 @@
+<% node['fb_reprepro']['options'].to_hash.each do |key, val| -%>
+<%=  key %><% if val %>=<%= val %><% end %>
+<% end -%>


### PR DESCRIPTION
This adds a cookbook to setup APT repositories using reprepro. It's a rework of an unpublished cookbook I've been running at home for a while. Tested on Debian.