### PR TITLE
Remove reference to oncalls from public doc

### DIFF
--- a/cookbooks/fb_fstab/README.md
+++ b/cookbooks/fb_fstab/README.md
@@ -35,7 +35,6 @@ add whatever filesystems you would like mounted and `fb_fstab` will, for each
 entry in the hash:
 * populate `/etc/fstab` for you
 * create the `mount_point` (but not parents) if it doesn't exist
-  (if you need parents created, please file a task against chef oncall)
 * mount the filesystem
 
 ### Global Options

--- a/cookbooks/fb_modprobe/providers/module.rb
+++ b/cookbooks/fb_modprobe/providers/module.rb
@@ -33,7 +33,6 @@ def modprobe_module(module_name, params, timeout, verbose, unload)
           Parameters for built-in modules must be passed on the kernel cmdline.
           Prefix the parameter with the module name and a dot.
           Examples: "ipv6.autoconf=1", "mlx4_en.udp_rss=1
-          Contact the kernel oncall if you have any questions about this.
         FAIL
       end
       return True


### PR DESCRIPTION
Hi oscore :),

Was just browsing the repo, considering using some of this stuff for my own infra and came accross a reference to the chef oncall, which probably shouldn't be laying around open source code.

Signed-off-by: Julien 'Lta' BALLET <contact@lta.io>