### PR TITLE
Added archlinux support

### DIFF
--- a/cookbooks/fb_systemd/README.md
+++ b/cookbooks/fb_systemd/README.md
@@ -22,8 +22,10 @@ Attributes
 * node['fb_systemd']['logind']['enable']
 * node['fb_systemd']['logind']['config']
 * node['fb_systemd']['networkd']['enable']
+* node['fb_systemd']['networkd']['ignore']
 * node['fb_systemd']['resolved']['enable']
 * node['fb_systemd']['resolved']['config']
+* node['fb_systemd']['resolved']['ignore']
 * node['fb_systemd']['timesyncd']['enable']
 * node['fb_systemd']['timesyncd']['config']
 * node['fb_systemd']['coredump']
@@ -154,6 +156,10 @@ using the `node['fb_systemd']['logind']['config']` attribute, according to the
 You can choose whether or not to enable `systemd-networkd` with the
 `node['fb_systemd']['networkd']['enable']` attribute, which defaults to `false`.
 
+If you want to want to totally disable any networkd management by this cookbook
+(e.g. so you can manage it yourself), you can set the
+`node['fb_systemd']['networkd']['ignore']` attribute, which defaults to `false`.
+
 Note that this cookbook does not manage network configuration profiles. If you 
 drop `netdev`, `link`, `network` definitions under `/etc/systemd/network` from
 another cookbook you'll want to request a restart of the `systemd-networkd`
@@ -162,6 +168,11 @@ service.
 ### resolved configuration
 You can choose whether or not to enable `systemd-resolved` with the
 `node['fb_systemd']['resolved']['enable']` attribute, which defaults to `false`.
+
+If you want to want to totally disable any resolved management by this cookbook
+(e.g. so you can manage it yourself), you can set the
+`node['fb_systemd']['resolved']['ignore']` attribute, which defaults to `false`.
+
 Note that this will also enable the `nss-resolve` resolver in 
 `/etc/nsswitch.conf` in place of the glibc `dns` one (using the API provided by
 `fb_nsswitch`). Resolved can be configured using the

--- a/cookbooks/fb_systemd/attributes/default.rb
+++ b/cookbooks/fb_systemd/attributes/default.rb
@@ -79,9 +79,11 @@ default['fb_systemd'] = {
   },
   'networkd' => {
     'enable' => false,
+    'ignore' => false,
   },
   'resolved' => {
     'enable' => false,
+    'ignore' => false,
     'config' => {},
   },
   'timesyncd' => {

--- a/cookbooks/fb_systemd/recipes/default.rb
+++ b/cookbooks/fb_systemd/recipes/default.rb
@@ -46,6 +46,11 @@ when 'debian'
   end
 
   systemd_prefix = ''
+when 'arch'
+  systemd_packages += [
+    'libsystemd',
+    'systemd-sysvcompat',
+  ]
 else
   fail 'fb_systemd is not supported on this platform.'
 end

--- a/cookbooks/fb_systemd/recipes/networkd.rb
+++ b/cookbooks/fb_systemd/recipes/networkd.rb
@@ -16,11 +16,13 @@
   systemd-networkd.service
 }.each do |svc|
   service svc do
+    not_if { node['fb_systemd']['networkd']['ignore'] }
     only_if { node['fb_systemd']['networkd']['enable'] }
     action [:enable, :start]
   end
 
   service "disable #{svc}" do
+    not_if { node['fb_systemd']['networkd']['ignore'] }
     not_if { node['fb_systemd']['networkd']['enable'] }
     service_name svc
     action [:stop, :disable]

--- a/cookbooks/fb_systemd/recipes/resolved.rb
+++ b/cookbooks/fb_systemd/recipes/resolved.rb
@@ -13,6 +13,7 @@
 #
 
 template '/etc/systemd/resolved.conf' do
+  not_if { node['fb_systemd']['resolved']['ignore'] }
   source 'systemd.conf.erb'
   owner 'root'
   group 'root'
@@ -30,6 +31,7 @@ end
 # to place the resolver between mymachines and myhostname as recommended by
 # upstream.
 ruby_block 'enable nss-resolve' do
+  not_if { node['fb_systemd']['resolved']['ignore'] }
   only_if { node['fb_systemd']['resolved']['enable'] }
   block do
     node.default['fb_nsswitch']['databases']['hosts'].delete('dns')
@@ -50,11 +52,13 @@ ruby_block 'enable nss-resolve' do
 end
 
 service 'systemd-resolved' do
+  not_if { node['fb_systemd']['resolved']['ignore'] }
   only_if { node['fb_systemd']['resolved']['enable'] }
   action [:enable, :start]
 end
 
 service 'disable systemd-resolved' do
+  not_if { node['fb_systemd']['resolved']['ignore'] }
   not_if { node['fb_systemd']['resolved']['enable'] }
   service_name 'systemd-resolved'
   action [:stop, :disable]


### PR DESCRIPTION
1. Added a systemd package list for arch, so the packages can be managed by this cookbook, instead of failing.
1. Added attributes `node['fb_systemd']['networkd']['ignore']` and `node['fb_systemd']['resolved']['ignore']` to prevent this cookbook from taking any action on the networkd/resolved resources. [Example of this in action](https://gist.github.com/zfjagann/507e3b48a78350e716119e962b496292)