### PR TITLE
opensource a few more cookbooks

### DIFF
--- a/cookbooks/fb_launchd/README.md
+++ b/cookbooks/fb_launchd/README.md
@@ -1,0 +1,39 @@
+fb_launchd Cookbook
+=========================
+This cookbook is similar to `fb_timers`. It manages launchd resources that
+describe scheduled or cron-like actions - e.g. those that run a program at a
+defined time. For persistent daemons/services, define your resource explicitly
+in terms of Chef `launchd` or `service` resources.
+
+Requirements
+------------
+This cookbook only works on Mac OS X (which is the only platform where launchd
+itself is supported).
+
+Attributes
+----------
+* node['fb_launchd']['jobs'][$JOB]
+* node['fb_launchd']['prefix']
+
+Usage
+-----
+Include this recipe and add any launchd items you want to setup to the
+`node['fb_launchd']['jobs']` attribute. Use the item label as key, and see
+the [launchd resource](https://docs.chef.io/resource_launchd.html) for supported
+values; at a minimum, you'll want to set `program_arguments` to define what's
+going to be run. Note that the `label` and `key` properties are not supported by
+`fb_launchd`. Example:
+
+```ruby
+node.default['fb_launchd']['jobs']['chefctl'] = {
+  'program_arguments' => ['/opt/scripts/chef/chefctl.sh'],
+  'run_at_load' => true,
+  'start_interval' => 1800,
+  'time_out' => 600
+}
+```
+
+**NOTE**: You should override the default value of the
+`node['fb_launchd']['prefix']` attribute in a recipe (e.g. your custom init
+recipe). If you do not do this, `fb_launchd` will assume a label prefix of
+`com.facebook.chef`.

--- a/cookbooks/fb_launchd/attributes/default.rb
+++ b/cookbooks/fb_launchd/attributes/default.rb
@@ -1,0 +1,18 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+default['fb_launchd'] = {
+  # Prefix all launchd agents/daemons will be created under.
+  'prefix' => 'com.facebook.managed',
+
+  # Any user-specified jobs to manage. Attributes are those used by the launchd
+  # resource. See README.md for more details.
+  'jobs' => {},
+}

--- a/cookbooks/fb_launchd/metadata.rb
+++ b/cookbooks/fb_launchd/metadata.rb
@@ -1,0 +1,11 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'fb_launchd'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'BSD-3-Clause'
+description 'Installs/Configures Chef-defined launchd plists'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+supports 'mac_os_x'
+depends 'fb_helpers'

--- a/cookbooks/fb_launchd/recipes/default.rb
+++ b/cookbooks/fb_launchd/recipes/default.rb
@@ -1,0 +1,15 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+unless node.macosx?
+  fail 'fb_launchd is only available on macOS'
+end
+
+fb_launchd 'Managing all of launchd'

--- a/cookbooks/fb_launchd/resources/default.rb
+++ b/cookbooks/fb_launchd/resources/default.rb
@@ -1,0 +1,100 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+provides :fb_launchd, :os => 'darwin'
+
+default_action :run
+
+def whyrun_supported?
+  true
+end
+
+# Attributes that circumvent or defeat the purpose of using launchd as a node
+# API. Blacklist them so that this blows up when they're used. If you really
+# want to use these, just make a launchd resource instead.
+BLACKLISTED_ATTRIBUTES = %w{
+  label
+  path
+}.freeze
+
+# Plist directories in which to search for managed jobs.
+PLIST_DIRECTORIES = %w{
+  /Library/LaunchAgents
+  /Library/LaunchDaemons
+}.freeze
+
+action :run do
+  # The prefix should look like a normal label without a trailing '.' and
+  # *hopefully* no globs, but let's be on the safe side...
+  prefix = Chef::Util::PathHelper.escape_glob(node['fb_launchd']['prefix'])
+  if prefix.end_with?('.')
+    fail "fb_launchd: prefix '#{prefix}' must not end with a trailing '.'"
+  end
+
+  # Delete old jobs first.
+  managed_plists(prefix).each do |path|
+    label = ::File.basename(path, '.plist')
+    name = label.sub(prefix + '.', '')
+    next if node['fb_launchd']['jobs'].include?(name)
+
+    # Delete with 'path' specified to enforce that we delete the right one.
+    Chef::Log.debug("fb_launchd: deleting #{label}")
+    launchd_resource(label, :delete, { 'path' => path })
+  end
+
+  # Set up current jobs.
+  node['fb_launchd']['jobs'].each do |name, attrs|
+    if attrs.keys.any? { |k| BLACKLISTED_ATTRIBUTES.include?(k) }
+      fail "fb_launchd[#{name}]: uses a blacklisted attribute (one of " +
+        "#{BLACKLISTED_ATTRIBUTES}). If you want to use them, create a " +
+        "'launchd' resource instead"
+    end
+
+    # Determine our label. The directory (/Library/LaunchDaemons or
+    # /Library/LaunchAgents) is determined by the label + type (which defaults
+    # to daemon if unspecified).
+    label = "#{prefix}.#{name}"
+
+    # Create resource
+    launchd_resource(label, attrs.fetch('action', :enable), attrs)
+  end
+end
+
+action_class do
+  # Constructs a new launchd resource with label 'label' and action 'action'.
+  # attrs is a Hash of key/value pairs of launchd attributes and their values.
+  # Returns the new launchd resource.
+  def launchd_resource(label, action, attrs = {})
+    Chef::Log.debug(
+      "fb_launchd: new launchd resource '#{label}' with action '#{action}' " +
+      "and attributes #{attrs}",
+    )
+    return unless label
+
+    res = launchd label do
+      action action.to_sym
+    end
+    attrs.each do |attribute, value|
+      next if attribute == 'action'
+      res.send(attribute.to_sym, value)
+    end
+
+    res
+  end
+
+  # Finds any managed plists in the standard launchd directories with the
+  # specified prefix. Returns a list of paths to the managed plists.
+  def managed_plists(prefix)
+    PLIST_DIRECTORIES.map do |dir|
+      plist_glob = ::File.join(::File.expand_path(dir), "*#{prefix}*.plist")
+      ::Dir.glob(plist_glob)
+    end.flatten
+  end
+end

--- a/cookbooks/fb_ldconfig/README.md
+++ b/cookbooks/fb_ldconfig/README.md
@@ -1,0 +1,23 @@
+fb_ldconfig Cookbook
+====================
+This cookbook manages `/etc/ld.so.conf` and the contents of `/etc/ld.so.conf.d`.
+
+Requirements
+------------
+CentOS
+
+Attributes
+----------
+* node['fb_ldconfig']['ld.so.conf']
+
+Usage
+-----
+Include `fb_ldconfig` and append to `node['fb_ldconfig']['ld.so.conf']` any
+additional paths the dynamic linker should use.
+
+```
+node.default['fb_ldconfig']['ld.so.conf'] << '/usr/local/lib'
+```
+
+This cookbook will delete any configs under `/etc/ld.so.conf.d` that aren't
+owned by an installed RPM package.

--- a/cookbooks/fb_ldconfig/attributes/default.rb
+++ b/cookbooks/fb_ldconfig/attributes/default.rb
@@ -1,0 +1,13 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+default['fb_ldconfig'] = {
+  'ld.so.conf' => [],
+}

--- a/cookbooks/fb_ldconfig/files/default/ld.so.conf
+++ b/cookbooks/fb_ldconfig/files/default/ld.so.conf
@@ -1,0 +1,4 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_ldconfig/README.md
+
+include ld.so.conf.d/*.conf

--- a/cookbooks/fb_ldconfig/metadata.rb
+++ b/cookbooks/fb_ldconfig/metadata.rb
@@ -1,0 +1,11 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'fb_ldconfig'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'BSD-3-Clause'
+description 'Manage /etc/ld.so.conf'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.0.1'
+supports 'centos'
+depends 'fb_helpers'

--- a/cookbooks/fb_ldconfig/recipes/default.rb
+++ b/cookbooks/fb_ldconfig/recipes/default.rb
@@ -1,0 +1,61 @@
+#
+# Cookbook Name:: fb_ldconfig
+# Recipe:: default
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+unless node.centos?
+  fail 'fb_ldconfig is only supported on CentOS'
+end
+
+execute 'ldconfig' do
+  command '/sbin/ldconfig'
+  action :nothing
+end
+
+cookbook_file '/etc/ld.so.conf' do
+  source 'ld.so.conf'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  # immediately because stuff in the run probably needs this
+  notifies :run, 'execute[ldconfig]', :immediately
+end
+
+template '/etc/ld.so.conf.d/chef.conf' do
+  source 'ld.so.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  # immediately because stuff in the run probably needs this
+  notifies :run, 'execute[ldconfig]', :immediately
+end
+
+files = Dir.glob('/etc/ld.so.conf.d/*').reject do |x|
+  File.basename(x) == 'chef.conf'
+end
+unless files.empty?
+  # RPM will exit with zero if all the files are owned by a package, and
+  # non-zero if there are any strays.
+  s = Mixlib::ShellOut.new("/bin/rpm -qf #{files.join(' ')}").run_command
+  if s.exitstatus != 0
+    # Parse the RPM output to find the strays and delete them
+    s.stdout.split("\n").each do |line|
+      m = /file (.*) is not owned by any package/.match(line.strip)
+      next unless m
+
+      file m[1] do
+        action :delete
+        notifies :run, 'execute[ldconfig]', :immediately
+      end
+    end
+  end
+end

--- a/cookbooks/fb_ldconfig/templates/default/ld.so.conf.erb
+++ b/cookbooks/fb_ldconfig/templates/default/ld.so.conf.erb
@@ -1,0 +1,6 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_ldconfig/README.md
+
+<% node['fb_ldconfig']['ld.so.conf'].sort.uniq.each do |path| %>
+<%=  path %>
+<% end %>

--- a/cookbooks/fb_sdparm/README.md
+++ b/cookbooks/fb_sdparm/README.md
@@ -1,0 +1,58 @@
+fb_sdparm Cookbook
+==================
+Allows setting of whitelisted sdparm parameters.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_sdparm']['enforce']
+* node['fb_sdparm']['settings']
+
+Usage
+-----
+`node['fb_sdparm']['enforce']` (Boolean)
+This determines if Chef will actually try to set any settings specified
+for the role. Defaults to false to be safe.
+
+`node['fb_sdparm']['settings']` (Hash)
+This is a hash that specifies sdparm settings to apply to disks. The settings
+are bifurcated by whether disks are rotational. We explicitly do not support
+assigning settings by drive letter because drive letters are not guaranteed to
+consistently map to devices.
+
+Only WCE and RCD are supported for now. If you'd like to set another param,
+update the `param_whitelist` in the custom resource definition.
+
+Settings are applied with the `--save` option to make them durable to power
+loss.
+
+This recipe will always attempt to update the `cache_type` entry in sysfs if it
+detects that it has become out of sync with what is set on the drive.
+
+If updating drive settings or `cache_type` fails, we fail the Chef run.
+
+You are responsible for ensuring this runs only on supported hardware. For
+example, disks behind an LSI RAID card will always fail attempts to set values.
+This will result in failing the Chef run.
+
+Example:
+
+```
+node.default['fb_sdparm']['enforce'] = true
+{
+  'rotational' => {
+    'WCE' => 1,
+    'RCD' => 0,
+  },
+  'non-rotational' => {
+    'WCE' => 1,
+    'RCD' => 0,
+  },
+}.each do |type, tconfig|
+  tconfig.each do |key, val|
+    node.default['fb_sdparm'][type][key] = val
+  end
+end
+```

--- a/cookbooks/fb_sdparm/attributes/default.rb
+++ b/cookbooks/fb_sdparm/attributes/default.rb
@@ -1,0 +1,17 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+default['fb_sdparm'] = {
+  'enforce' => false,
+  'settings' => {
+    'rotational' => {},
+    'non-rotational' => {},
+  },
+}

--- a/cookbooks/fb_sdparm/metadata.rb
+++ b/cookbooks/fb_sdparm/metadata.rb
@@ -1,0 +1,13 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'fb_sdparm'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'BSD-3-Clause'
+description 'Installs/Configures sdparm'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+supports 'centos'
+depends 'fb_helpers'
+depends 'fb_sysfs'
+depends 'fb_fstab'

--- a/cookbooks/fb_sdparm/recipes/default.rb
+++ b/cookbooks/fb_sdparm/recipes/default.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: fb_sdparm
+# Recipe:: default
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+package 'sdparm' do
+  action :upgrade
+end
+
+fb_sdparm 'set sdparm options' do
+  only_if { node['fb_sdparm']['enforce'] }
+end

--- a/cookbooks/fb_sdparm/resources/default.rb
+++ b/cookbooks/fb_sdparm/resources/default.rb
@@ -1,0 +1,138 @@
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+default_action :set
+resource_name :fb_sdparm
+
+def whyrun_supported?
+  true
+end
+
+def get_sdparm_value(param, device)
+  cmd = Mixlib::ShellOut.new("sdparm --get #{param} /dev/#{device}").run_command
+  cmd.error!
+  output = cmd.stdout
+  # Match anything besides whitespace between '=' and paren
+  re = /^#{param}\s+(\w+)\s/m
+  match_obj = re.match(output)
+  unless match_obj
+    fail 'fb_sdparm: could not parse the output of sdparm'
+  end
+
+  match_data = match_obj[1]
+  if match_data =~ /^\s*$/
+    fail "fb_sdparm: could not get sdparm value for: #{param}"
+  end
+  return match_data.to_s.strip
+end
+
+def set_sdparm_value(param, value, device, device_type)
+  command = "sdparm --set #{param}=#{value}"
+  # SATA devices do not support --save
+  unless device_type == 'ATA'
+    command << ' --save'
+  end
+  command << " /dev/#{device}"
+  s = Mixlib::ShellOut.new(command).run_command
+  s.error!
+  new_val = get_sdparm_value(param, device)
+  if new_val.to_s != value.to_s
+    fail "fb_sdparm: drive still reports value as #{new_val}, " +
+      "should be #{value}!"
+  end
+  Chef::Log.info("fb_sdparm: #{device}: set sdparm #{param} to #{value}.")
+end
+
+def cache_type_path_for_device(device)
+  return ::Dir.glob(
+    "/sys/block/#{device}/device/scsi_disk/*/cache_type",
+  ).first
+end
+
+def get_cache_type_desired_and_path(device)
+  # key is a 2-item array of WCE, RCD
+  cache_type_expected_values = {
+    [0, 0] => 'write through',
+    [0, 1] => 'none',
+    [1, 0] => 'write back',
+    [1, 1] => 'write back, no read (daft)',
+  }
+  wce = get_sdparm_value('WCE', device).to_i
+  rcd = get_sdparm_value('RCD', device).to_i
+
+  desired_cache_type = cache_type_expected_values[[wce, rcd]]
+  cache_type_path = cache_type_path_for_device(device)
+  return desired_cache_type, cache_type_path
+end
+
+action :set do
+  param_whitelist = [
+    'RCD',
+    'WCE',
+  ]
+
+  in_maint_disks = FB::Fstab.get_in_maint_disks
+  Chef::Log.debug("in_maint_disks: #{in_maint_disks}")
+  root_dev = node.device_of_mount('/')
+  disks = node['block_device'].to_hash.reject do |dev, attrs|
+    ['ram', 'loop', 'dm-'].include?(dev.delete('0-9')) ||
+      (root_dev && root_dev.start_with?(dev)) ||
+      dev.start_with?('nvme') ||
+      dev.start_with?('md') ||
+      dev.start_with?('fio') ||
+      attrs['model'] == 'XP6210-4B2048' || # nytro flash card
+      in_maint_disks.include?("/dev/#{dev}")
+  end
+  Chef::Log.debug("disks: #{disks}")
+
+
+  rotational_settings = node['fb_sdparm']['settings']['rotational'] ?
+    node['fb_sdparm']['settings']['rotational'].to_hash :
+    {}
+
+  non_rotational_settings = node['fb_sdparm']['settings']['non-rotational'] ?
+    node['fb_sdparm']['settings']['non-rotational'].to_hash :
+    {}
+
+  disks.each do |disk, details|
+    if details['rotational'].to_i == 1
+      settings = rotational_settings
+    elsif details['rotational'].to_i.zero?
+      settings = non_rotational_settings
+    else
+      # something is very wrong
+      fail "fb_sdparm: disk #{disk} has no rotational value!"
+    end
+
+    settings.each do |param, desired_value|
+      unless param_whitelist.include?(param)
+        # do not let someone silently fail to set value due to typos
+        fail "fb_sdparm: param #{param} is not yet supported by fb_sdparm!"
+      end
+
+      current_value = get_sdparm_value(param, disk)
+      # Don't bother setting it if it's already correct
+      if current_value.to_s == desired_value.to_s
+        Chef::Log.debug("fb_sdparm: #{param} value already set to " +
+                       "#{desired_value}.")
+      else
+        converge_by 'setting sdparm value' do
+          set_sdparm_value(param, desired_value, disk, details['vendor'])
+        end
+      end
+    end
+    desired_cache_type, cache_type_path = get_cache_type_desired_and_path(disk)
+    fb_sysfs cache_type_path do
+      type :string
+      value desired_cache_type + "\n"
+    end
+  end
+end


### PR DESCRIPTION
Import from our internal repo:
- fb_launchd: manage launchd resources that describe scheduled or cron-like actions
- fb_ldconfig: manage `/etc/ld.so.conf` and the contents of `/etc/ld.so.conf.d`
- fb_sdparm: manage specific sdparm parameters