### PR TITLE
fb_init_sample: turn off dnsmasq on sid

### DIFF
--- a/cookbooks/fb_init_sample/recipes/default.rb
+++ b/cookbooks/fb_init_sample/recipes/default.rb
@@ -85,6 +85,10 @@ end
 
 unless node.centos6?
   include_recipe 'fb_apcupsd'
+  # Turn off dnsmasq on sid as it doesn't play well with travis
+  if node.debian? && node['platform_version'].include?('sid')
+    node.default['fb_dnsmasq']['enable'] = false
+  end
   include_recipe 'fb_dnsmasq'
 end
 include_recipe 'fb_collectd'


### PR DESCRIPTION
Summary: This breaks Travis, so turn it off for now

Differential Revision: D13780341
