### PR TITLE
Ensure attributes for fb_timers only runs on supported OSes

### DIFF
--- a/cookbooks/fb_timers/attributes/default.rb
+++ b/cookbooks/fb_timers/attributes/default.rb
@@ -8,6 +8,8 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 #
 
+return unless node.centos? || node.debian? || node.ubuntu?
+
 default['fb_timers'] = {
   'jobs' => {},
 


### PR DESCRIPTION
Currently, if fb_timers is in a `depends` on a cookbook but *not* included into the runlist, it will fail on any OS where it isn't supported.

This diff ensures that the attributes only run on OSes where it is intended to run. 