### PR TITLE
Updating keys.rb to use long format fingerprint

### DIFF
--- a/cookbooks/fb_apt/providers/keys.rb
+++ b/cookbooks/fb_apt/providers/keys.rb
@@ -22,13 +22,13 @@ action :run do
   if keys && keyring
     installed_keys = []
     if ::File.exist?(keyring)
-      cmd = Mixlib::ShellOut.new("LANG=C apt-key --keyring #{keyring} list")
+      cmd = Mixlib::ShellOut.new("LANG=C apt-key --keyring #{keyring} finger")
       cmd.run_command
       cmd.error!
       output = cmd.stdout.split("\n")
       Chef::Log.debug("apt-key output: #{output.join("\n")}")
-      installed_keys = output.select { |x| x.match(/([\w|\s]+)$/) }.map do |x|
-        x[/(?<keyid>[\w]{4}\s[\w]{4})$/, 'keyid'].sub(' ', '')
+      installed_keys = output.select { |x| x.match(/([\w]{4})$/) }.map do |x|
+        x[/(?<keyid>[\w]{4}\s[\w]{4})$/, 'keyid'].delete(' ')
       end
     end
     Chef::Log.debug("Installed keys: #{installed_keys.join(', ')}")

--- a/cookbooks/fb_apt/providers/keys.rb
+++ b/cookbooks/fb_apt/providers/keys.rb
@@ -28,7 +28,7 @@ action :run do
       output = cmd.stdout.split("\n")
       Chef::Log.debug("apt-key output: #{output.join("\n")}")
       installed_keys = output.select { |x| x.match(/([\w|\s]+)$/) }.map do |x|
-        x[%r/(?<keyid>[\w]{4}\s[\w]{4})$/, 'keyid'].sub(' ', '')
+        x[%r{(?<keyid>[\w]{4}\s[\w]{4})$}, 'keyid'].sub(' ', '')
       end
     end
     Chef::Log.debug("Installed keys: #{installed_keys.join(', ')}")

--- a/cookbooks/fb_apt/providers/keys.rb
+++ b/cookbooks/fb_apt/providers/keys.rb
@@ -27,8 +27,8 @@ action :run do
       cmd.error!
       output = cmd.stdout.split("\n")
       Chef::Log.debug("apt-key output: #{output.join("\n")}")
-      installed_keys = output.select { |x| x.start_with?('pub') }.map do |x|
-        x[%r{pub.*/(?<keyid>[A-Z0-9]*)}, 'keyid']
+      installed_keys = output.select { |x| x.match(/([A-Z0-9]{4}\s[A-Z0-9]{4})$/) }.map do |x|
+        x[%r{(?<keyid>[A-Z0-9]{4}\s[A-Z0-9]{4})$}, 'keyid'].sub(' ', '')
       end
     end
     Chef::Log.debug("Installed keys: #{installed_keys.join(', ')}")

--- a/cookbooks/fb_apt/providers/keys.rb
+++ b/cookbooks/fb_apt/providers/keys.rb
@@ -27,8 +27,8 @@ action :run do
       cmd.error!
       output = cmd.stdout.split("\n")
       Chef::Log.debug("apt-key output: #{output.join("\n")}")
-      installed_keys = output.select { |x| x.match(/([A-Z0-9]{4}\s[A-Z0-9]{4})$/) }.map do |x|
-        x[%r{(?<keyid>[A-Z0-9]{4}\s[A-Z0-9]{4})$}, 'keyid'].sub(' ', '')
+      installed_keys = output.select { |x| x.match(/([\w|\s]+)$/) }.map do |x|
+        x[%r/(?<keyid>[\w]{4}\s[\w]{4})$/, 'keyid'].sub(' ', '')
       end
     end
     Chef::Log.debug("Installed keys: #{installed_keys.join(', ')}")

--- a/cookbooks/fb_apt/providers/keys.rb
+++ b/cookbooks/fb_apt/providers/keys.rb
@@ -27,7 +27,7 @@ action :run do
       cmd.error!
       output = cmd.stdout.split("\n")
       Chef::Log.debug("apt-key output: #{output.join("\n")}")
-      installed_keys = output.select { |x| x.match(/([\w]{4})$/) }.map do |x|
+      installed_keys = output.select { |x| x.match(/(\s\w{4}){5}/) }.map do |x|
         x[/(?<keyid>[\w]{4}\s[\w]{4})$/, 'keyid'].delete(' ')
       end
     end

--- a/cookbooks/fb_apt/providers/keys.rb
+++ b/cookbooks/fb_apt/providers/keys.rb
@@ -28,7 +28,7 @@ action :run do
       output = cmd.stdout.split("\n")
       Chef::Log.debug("apt-key output: #{output.join("\n")}")
       installed_keys = output.select { |x| x.match(/([\w|\s]+)$/) }.map do |x|
-        x[%r{(?<keyid>[\w]{4}\s[\w]{4})$}, 'keyid'].sub(' ', '')
+        x[/(?<keyid>[\w]{4}\s[\w]{4})$/, 'keyid'].sub(' ', '')
       end
     end
     Chef::Log.debug("Installed keys: #{installed_keys.join(', ')}")


### PR DESCRIPTION
Updating the regex in keys.rb to use match on long format fingerprint to get the key ID as the short form is removed in newer versions of apt-key.