### PR TITLE
chef: move Debian builds to stretch

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -35,15 +35,12 @@ platforms:
         # we need dmidecode for the Ohai shard plugin
         - apt-get install -y dmidecode
       run_command: /sbin/init
-  - name: debian-8
+  - name: debian-9
     driver_config:
       provision_command:
         # we need dmidecode for the Ohai shard plugin
-        # we need wget because...
-        # https://github.com/test-kitchen/test-kitchen/issues/1018
-        # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=814070
-        - apt-get install -y wget dmidecode
-      run_command: /sbin/init
+        - apt-get install -y dmidecode
+      run_command: /bin/systemd
   - name: debian-sid
     driver_config:
       provision_command:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - INSTANCE=default-centos-7
     - INSTANCE=default-ubuntu-1404
     - INSTANCE=default-ubuntu-1604
-    - INSTANCE=default-debian-8
+    - INSTANCE=default-debian-9
     - INSTANCE=default-debian-sid
 
 matrix:


### PR DESCRIPTION
Summary:
Jessie is being moved to the archive
(https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html) and
stretch has been stable for a while, let's just use that instead.

Differential Revision: D14718155
