### PR TITLE
New cookbook: fb_users

### DIFF
--- a/cookbooks/fb_init_sample/metadata.rb
+++ b/cookbooks/fb_init_sample/metadata.rb
@@ -72,6 +72,7 @@ end
   'fb_timers',
   'fb_tmpclean',
   'fb_util_linux',
+  'fb_users',
 ].each do |cb|
   depends cb
 end

--- a/cookbooks/fb_init_sample/recipes/default.rb
+++ b/cookbooks/fb_init_sample/recipes/default.rb
@@ -79,6 +79,7 @@ include_recipe 'fb_limits'
 include_recipe 'fb_hostconf'
 include_recipe 'fb_sysctl'
 # HERE: networking
+include_recipe 'fb_users'
 if node.centos?
   # We turn this off because the override causes intermittent failures in
   # Travis when rsyslog is restarted

--- a/cookbooks/fb_users/README.md
+++ b/cookbooks/fb_users/README.md
@@ -1,0 +1,137 @@
+fb_users Cookbook
+=================
+A simple cookbook to provide an attribute-driven API around users and groups
+and enforce consistent UIDs and GIDs.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_users']['user_defaults']
+* node['fb_users']['user_defaults']['manage_home']
+* node['fb_users']['user_defaults']['shell']
+* node['fb_users']['user_defaults']['gid']
+* node['fb_users']['users']
+* node['fb_users']['users'][$USER]
+* node['fb_users']['groups']
+* node['fb_users']['groups'][$GROUP]
+
+Usage
+-----
+### Consistent data vs dynamic data
+This cookbook draws a hard distinction between information that should not
+be changable across an organization and information that should.
+
+Information that should not change like what UID a given user gets when they
+are added to a system is stored differently from information that is dynamic
+per-system like if the user is on the system and what groups they are a part
+of.
+
+### Pre-req: Initializing Consistent data with UID_MAP AND GID_MAP
+UIDs, GIDs, and (optional) user/group "comments" are considered consistent data
+by `fb_users`. These exist in a single map. They do *not* effect what users or
+groups are installed on a system are are just a source of data.
+
+In order to make it this data not modifiable through the run, we put it in class constants, instead of in the node object. This is not - and should not - be a common pattern, but it's a clean way of keeping this data (somewhat more) singley-definable.
+
+In a cookbook of your choice, simply re-open the `FB::Users` class, and define
+class constants like so:
+
+```
+module FB
+  class Users
+    UID_MAP = {
+      'root' => {
+        'uid' => 0,
+      },
+
+      # staff...
+      'john' => {
+        'uid' => 1000,
+        'comment' => 'John Smith',
+      },
+      'sam' => {
+        'uid' => 1001,
+        'comment' => 'Sam Theman',
+      },
+      ...
+
+      # service accounts, >= 6k
+      'app1' => {
+        'uid' => 6000,
+      },
+      'app2' => {
+        'uid' => 6001,
+      },
+      ...
+    }.freeze
+
+    GID_MAP = {
+      'root' => {
+        'gid' => 0,
+      }
+      'users' => {
+        'gid' => 100,
+      },
+      'docker' => {
+        'gid' => 130,
+        'comment' => 'Provides access to docker',
+      },
+      ...
+    }
+  end
+end
+```
+
+The default recipe will validate there are no UID or GID conflicts for you,
+but you should keep users and groups in order of their UID/GID for your own
+sanity.
+
+### Users and Groups
+Users and groups are setup using the `users` and `groups` hashes and are
+straight forward:
+
+```
+node.default['fb_users']['users']['john'] = {
+  'shell' => '/bin/zsh',
+  'gid' => 'users',
+}
+node.default['fb_users']['groups']['admins'] = {
+  'members' => ['john'],
+}
+```
+
+`fb_users` will take care to get ordering right to ensure relevant primary
+groups exist before creating users that depend on them and all users exist
+before group membership is managed.
+
+By design, we do not accept all values. Here are the values we do accept:
+* `comment`
+* `gid`
+* `home`
+* `manage_home`
+* `password`
+* `shell`
+
+They are all optional, see the next section for how default values for these
+work.
+
+## Defaults for users
+Values not specified for users will be handled as follows:
+
+* home - will default to `/home/$USER`
+* shell - will default to `node['fb_users']['user_defaults']['shell']`
+* gid - will default to `node['fb_users']['user_defaults']['gid']`
+* manage_home - this one is more complex:
+  * if `node['fb_users']['user_defaults']['manage_home']` is specified, that
+    value will be used
+  * otherwise, if the `dirname` of the `home` value appears to be on NFS or
+    `autofs`, the value will be set to `false`
+  * otherwise the value will be set to `true`
+
+`gid` is required and has no default. It must be set to a group name that appears
+in `GID_MAP`.
+
+For all other values we accept, they will only be passed to the resource if
+they exist in the user's hash.

--- a/cookbooks/fb_users/README.md
+++ b/cookbooks/fb_users/README.md
@@ -88,6 +88,10 @@ The default recipe will validate there are no UID or GID conflicts for you,
 but you should keep users and groups in order of their UID/GID for your own
 sanity.
 
+You may specify a `comment` in addition to `uid`/`gid` for the entity.
+
+All other values must be set in the node object.
+
 ### Users and Groups
 Users and groups are setup using the `users` and `groups` hashes and are
 straight forward:
@@ -107,7 +111,6 @@ groups exist before creating users that depend on them and all users exist
 before group membership is managed.
 
 By design, we do not accept all values. Here are the values we do accept:
-* `comment`
 * `gid`
 * `home`
 * `manage_home`
@@ -116,6 +119,27 @@ By design, we do not accept all values. Here are the values we do accept:
 
 They are all optional, see the next section for how default values for these
 work.
+
+## Passwords in data_bags
+
+`fb_users` will also look for user passwords in a data_bag called
+`fb_users_auth`. The node takes precedent, but if no password is set there,
+then data_bags will be checked. This feature is to allow automation of password
+generation or syncing.
+
+To use this the item must be named the same as the user, and the element inside
+of the item should be `password`. For example,
+`data_bags/fb_users_auth/testuser.json` might have the content:
+
+```json
+{"id":"testuser","password":<encryptedpassword>}
+```
+
+An encrypted password string suitable for passing to the Chef `user` resource
+is expected.
+
+If a password is not found in either the node or a data_bag, no password is
+set and the user will not be to authenticate via password.
 
 ## Defaults for users
 Values not specified for users will be handled as follows:

--- a/cookbooks/fb_users/README.md
+++ b/cookbooks/fb_users/README.md
@@ -100,9 +100,11 @@ straight forward:
 node.default['fb_users']['users']['john'] = {
   'shell' => '/bin/zsh',
   'gid' => 'users',
+  'action' => :add,
 }
 node.default['fb_users']['groups']['admins'] = {
   'members' => ['john'],
+  'action' => :add,
 }
 ```
 
@@ -119,6 +121,14 @@ By design, we do not accept all values. Here are the values we do accept:
 
 They are all optional, see the next section for how default values for these
 work.
+
+Note that `action` may be `:add` or `:delete`. The default, if not set, is
+`:add`, but we highly recommend you be explicit. Doing so will make it really
+easy, for example, to set various users to `:delete` early on in your run,
+and then if later recipes add them, they'll be added, otherwise they'll be
+automatically cleaned up.
+
+Also see `initialize_group` helper below.
 
 ## Passwords in data_bags
 
@@ -159,3 +169,22 @@ in `GID_MAP`.
 
 For all other values we accept, they will only be passed to the resource if
 they exist in the user's hash.
+
+### Helper methods
+
+This cookbook provides a few helper methods for your convenience:
+
+#### FB::Users.initialize_group(node, groupname)
+
+Since initializing a group nicely involves setting `members` to an empty array
+so it may be appended to, we provide a simple method `FB::Users.initialize_group`
+which, *if* the group does not exist in the hash *or* was set to delete, will
+initialize it as an empty group to add.
+
+#### FB::Users.uid_to_name(uid)
+
+Given a UID for a user in the UID_MAP will return the name.
+
+#### FB::Users.gid_to_name(gid)
+
+Given a GID for a group in the GID_MAP will return the name.

--- a/cookbooks/fb_users/attributes/default.rb
+++ b/cookbooks/fb_users/attributes/default.rb
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2019-present, Vicarious, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['fb_users'] = {
+  'user_defaults' => {
+    'shell' => '/bin/bash',
+    'gid' => 'users',
+  },
+  'users' => {},
+  'groups' => {},
+}

--- a/cookbooks/fb_users/libraries/default.rb
+++ b/cookbooks/fb_users/libraries/default.rb
@@ -57,11 +57,15 @@ module FB
               'is not in the GID_MAP'
           end
           gid_int = false
+          # rubocop:disable Style/DoubleNegation
+          # rubocop:disable Lint/HandleExceptions
           begin
             gid_int = !!Integer(gid)
           rescue ArgumentError
             # expected
           end
+          # rubocop:enable Style/DoubleNegation
+          # rubocop:enable Lint/HandleExceptions
           if gid_int
             fail "fb_users[user]: User #{user} has an integer for primary" +
               ' group. Please specify a name.'

--- a/cookbooks/fb_users/libraries/default.rb
+++ b/cookbooks/fb_users/libraries/default.rb
@@ -20,7 +20,7 @@ module FB
     # To be called at runtime only.
     def self._validate(node)
       uids = {}
-      UID_MAP.each do |user, info|
+      UID_MAP&.each do |user, info|
         if uids[info['uid']]
           fail "fb_users[user]: User #{user} in UID map has a UID conflict"
         end
@@ -29,7 +29,7 @@ module FB
       end
 
       gids = {}
-      GID_MAP.each do |group, info|
+      GID_MAP&.each do |group, info|
         if gids[info['gid']]
           fail "fb_users[group]: group #{group} in GID map has a GID conflict"
         end

--- a/cookbooks/fb_users/libraries/default.rb
+++ b/cookbooks/fb_users/libraries/default.rb
@@ -21,7 +21,7 @@ module FB
     def self._validate(node)
       # if they're not using the API to add users or groups, then
       # don't fail on them not defining UID_MAP and GID_MAP
-      unless node['fb_users']['users'] || node['fb_users']['groups']
+      if node['fb_users']['users'].empty? && node['fb_users']['groups'].empty?
         return
       end
 

--- a/cookbooks/fb_users/libraries/default.rb
+++ b/cookbooks/fb_users/libraries/default.rb
@@ -84,6 +84,7 @@ module FB
           end
           # rubocop:enable Style/DoubleNegation
           # rubocop:enable Lint/HandleExceptions
+
           if gid_int
             fail "fb_users[user]: User #{user} has an integer for primary" +
               ' group. Please specify a name.'

--- a/cookbooks/fb_users/libraries/default.rb
+++ b/cookbooks/fb_users/libraries/default.rb
@@ -1,0 +1,81 @@
+#
+# Copyright (c) 2019-present, Vicarious, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module FB
+  class Users
+    # To be called at runtime only.
+    def self._validate(node)
+      uids = {}
+      UID_MAP.each do |user, info|
+        if uids[info['uid']]
+          fail "fb_users[user]: User #{user} in UID map has a UID conflict"
+        end
+
+        uids[info['uid']] = nil
+      end
+
+      gids = {}
+      GID_MAP.each do |group, info|
+        if gids[info['gid']]
+          fail "fb_users[group]: group #{group} in GID map has a GID conflict"
+        end
+
+        uids[info['gid']] = nil
+      end
+
+      if node['fb_users']['user_defaults']['gid']
+        gid = node['fb_users']['user_defaults']['gid']
+        unless GID_MAP[gid]
+          fail "fb_users[user]: Default group #{gid} has no GID in the " +
+            'GID_MAP - update, or unset it.'
+        end
+      end
+
+      node['fb_users']['users'].each do |user, info|
+        unless UID_MAP[user]
+          fail "fb_users[user]: User #{user} has no UID in the UID_MAP"
+        end
+
+        if info['gid']
+          gid = info['gid']
+          unless GID_MAP[gid]
+            fail "fb_users[user]: User #{user} has a group of #{gid} which " +
+              'is not in the GID_MAP'
+          end
+          gid_int = false
+          begin
+            gid_int = !!Integer(gid)
+          rescue ArgumentError
+            # expected
+          end
+          if gid_int
+            fail "fb_users[user]: User #{user} has an integer for primary" +
+              ' group. Please specify a name.'
+          end
+        elsif !node['fb_users']['user_defaults']['gid']
+          fail "fb_users[user]: User #{user} has no primary group (gid) " +
+            'and there is no default set.'
+        end
+      end
+      node['fb_users']['groups'].keys.sort.uniq do |group|
+        unless GID_MAP[group]
+          fail "fb_users[group]: Group #{group} has no GID in the GID_MAP"
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/fb_users/libraries/default.rb
+++ b/cookbooks/fb_users/libraries/default.rb
@@ -19,8 +19,14 @@ module FB
   class Users
     # To be called at runtime only.
     def self._validate(node)
+      # if they're not using the API to add users or groups, then
+      # don't fail on them not defining UID_MAP and GID_MAP
+      unless node['fb_users']['users'] || node['fb_users']['groups']
+        return
+      end
+
       uids = {}
-      UID_MAP&.each do |user, info|
+      UID_MAP.each do |user, info|
         if uids[info['uid']]
           fail "fb_users[user]: User #{user} in UID map has a UID conflict"
         end
@@ -29,7 +35,7 @@ module FB
       end
 
       gids = {}
-      GID_MAP&.each do |group, info|
+      GID_MAP.each do |group, info|
         if gids[info['gid']]
           fail "fb_users[group]: group #{group} in GID map has a GID conflict"
         end

--- a/cookbooks/fb_users/metadata.rb
+++ b/cookbooks/fb_users/metadata.rb
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2019-present, Vicarious, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name 'fb_users'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'Apache-2.0'
+description 'Configures users and groups'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+# never EVER change this number, ever.
+version '0.1.0'
+supports 'centos'
+supports 'debian'
+supports 'ubuntu'

--- a/cookbooks/fb_users/recipes/default.rb
+++ b/cookbooks/fb_users/recipes/default.rb
@@ -29,5 +29,8 @@ ohai 'fb_users reloading ohai->etc' do
 end
 
 fb_users 'converge users and groups' do
+  not_if do
+    node['fb_users']['users'].empty? && node['fb_users']['groups'].empty?
+  end
   notifies :reload, 'ohai[fb_users reloading ohai->etc]', :immediately
 end

--- a/cookbooks/fb_users/recipes/default.rb
+++ b/cookbooks/fb_users/recipes/default.rb
@@ -1,0 +1,33 @@
+#
+# Cookbook:: fb_users
+# Recipe:: default
+#
+# Copyright (c) 2019-present, Vicarious, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+whyrun_safe_ruby_block 'validate users and groups' do
+  block do
+    FB::Users._validate(node)
+  end
+end
+
+ohai 'fb_users reloading ohai->etc' do
+  action :nothing
+end
+
+fb_users 'converge users and groups' do
+  notifies :reload, 'ohai[fb_users reloading ohai->etc]', :immediately
+end

--- a/cookbooks/fb_users/resources/default.rb
+++ b/cookbooks/fb_users/resources/default.rb
@@ -48,7 +48,8 @@ action :manage do
         manage_homedir = true
         homebase = ::File.dirname(homedir)
         if node['filesystem']['by_mountpoint'][homebase]
-          homebase_type = node['filesystem']['by_mountpoint'][homebase]['fs_type']
+          homebase_type =
+            node['filesystem']['by_mountpoint'][homebase]['fs_type']
           if homebase_type.start_with?('nfs', 'autofs')
             manage_homedir = false
           end

--- a/cookbooks/fb_users/resources/default.rb
+++ b/cookbooks/fb_users/resources/default.rb
@@ -90,10 +90,14 @@ action :manage do
 
   # and then converge all groups
   node['fb_users']['groups'].each do |groupname, info|
-    group groupname do
+    # disableing fc009 becasue it triggers on 'comment' below which
+    # is already guarded by a version 'if'
+    group groupname do # ~FC009
       gid ::FB::Users::GID_MAP[groupname]['gid']
       members info['members'] if info['members']
-      comment info['comment'] if info['comment']
+      if FB::Version.new(Chef::VERSION) >= FB::Version.new('14.9')
+        comment info['comment'] if info['comment']
+      end
       append false
       action :create
     end

--- a/cookbooks/fb_users/resources/default.rb
+++ b/cookbooks/fb_users/resources/default.rb
@@ -1,0 +1,80 @@
+#
+# Copyright (c) 2019-present, Vicarious, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default_action [:manage]
+
+action :manage do
+  # You can't add users if their primary group doesn't exist. So, first
+  # we find all primary groups, and make sure they exist, or create them
+  if node['fb_users']['user_defaults']['gid']
+    pgroups = [node['fb_users']['user_defaults']['gid']]
+  end
+  pgroups += node['fb_users']['users'].map { |_, info| info['gid'] }
+  pgroups = pgroups.compact.sort.uniq
+  pgroups.each do |grp|
+    group "bootstrap #{grp}" do
+      group_name grp
+      gid ::FB::Users::GID_MAP[grp]['gid']
+      action :create
+    end
+  end
+
+  # Now we can add all the users
+  node['fb_users']['users'].each do |username, info|
+    mapinfo = ::FB::Users::UID_MAP[username]
+    pgroup = info['gid'] || node['fb_users']['user_defaults']['gid']
+    homedir = info['home'] || "/home/#{username}"
+    # If `manage_homedir` isn't set, we'll use a user-specified default.
+    # If *that* isn't set, then
+    manage_homedir = nil
+    unless info['manage_home']
+      if node['fb_users']['user_defaults']['manage_home']
+        manage_homedir = node['fb_users']['user_defaults']['manage_home']
+      else
+        manage_homedir = true
+        homebase = ::File.dirname(homedir)
+        if node['filesystem']['by_mountpoint'][homebase]
+          homebase_type = node['filesystem']['by_mountpoint'][homebase]['fs_type']
+          if homebase_type.start_with?('nfs', 'autofs')
+            manage_homedir = false
+          end
+        end
+      end
+    end
+
+    user username do
+      uid mapinfo['uid']
+      gid ::FB::Users::GID_MAP[pgroup]['gid']
+      shell info['shell'] || node['fb_users']['user_defaults']['shell']
+      manage_home manage_homedir
+      home homedir
+      comment mapinfo['comment'] if mapinfo['comment']
+      comment mapinfo['password'] if mapinfo['password']
+      action :create
+    end
+  end
+
+  # and then converge all groups
+  node['fb_users']['groups'].each do |groupname, info|
+    group groupname do
+      gid ::FB::Users::GID_MAP[groupname]['gid']
+      members info['members'] if info['members']
+      append false
+      action :create
+    end
+  end
+end


### PR DESCRIPTION
This cookbook is used to manage users via the FB attribute-driven model.

Adding users or groups is simply done in the node as you'd expect. The
README has copious documentation.

This has one significant departure from how most FB-style cookbooks
work, and that is that is it has users monkeypatch a class. The reason
for this is as follows. One important piece of a cookbook that managers
users is to enforce consistent UIDs and GIDs across the environment,
which means it should not be part of the API. As I recall, at FB these
exist in an attribute that "shouldn't be touched", and I wanted to keep
that general idea but formalize it better. Putting it in attributes
would mean users *always* pass in UIDs via the node which just begs for
bad behavior. So I decided to put it in a class constant.

The nice thing about this is that as long as the cookbook with the
monkeypatched library is *depended on* by anything in the base runlist,
from fb_users to fb_init to whatever, it all just works.

One other small change from how I recall FB doing this internally... the
UID/GID map can also include the user/group "comment" since that likely
also should be consistent across the world.