### PR TITLE
New cookbook: fb_sudo

### DIFF
--- a/cookbooks/fb_init_sample/metadata.rb
+++ b/cookbooks/fb_init_sample/metadata.rb
@@ -49,6 +49,7 @@ end
   'fb_sdparm',
   'fb_securetty',
   'fb_storage',
+  'fb_sudo',
   'fb_swap',
   'fb_sysctl',
   # no recipe, but we want the provider included

--- a/cookbooks/fb_init_sample/recipes/default.rb
+++ b/cookbooks/fb_init_sample/recipes/default.rb
@@ -88,7 +88,7 @@ include_recipe 'fb_fstab'
 include_recipe 'fb_logrotate'
 # HERE: autofs
 include_recipe 'fb_tmpclean'
-# HERE: sudo
+include_recipe 'fb_sudo'
 # HERE: ntp
 if node.centos? && !node.container?
   node.default['fb_ipset']['auto_cleanup'] = false

--- a/cookbooks/fb_sudo/README.md
+++ b/cookbooks/fb_sudo/README.md
@@ -1,0 +1,86 @@
+fb_sudo Cookbook
+================
+This cookbook installs sudo and provides an API to configure it.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_sudo']['aliases']
+* node['fb_sudo']['aliases']['host']
+* node['fb_sudo']['aliases']['host'][$ALIAS]
+* node['fb_sudo']['aliases']['user']
+* node['fb_sudo']['aliases']['user'][$ALIAS]
+* node['fb_sudo']['aliases']['command']
+* node['fb_sudo']['aliases']['command'][$ALIAS]
+* node['fb_sudo']['aliases']['runas']
+* node['fb_sudo']['aliases']['runas'][$ALIAS]
+* node['fb_sudo']['defaults'][$SETTING]
+* node['fb_sudo']['default_overrides'][$OVERRIDE]
+* node['fb_sudo']['users'][$USER]
+
+Usage
+-----
+Include `fb_sudo` to install sudo. By default users in the `sudo` group will
+be granted full access. Additional rules can be setup using
+`node['fb_sudo']['users']`.
+
+
+### Defaults
+Defaults is probably the most interesting part of the API. It's a hash where the
+value is either bool or a string. If it's a bool then the default will be
+represented as `key` or `!key` as appropriate. If it's a string, then it will
+represented as `key=val`. E.g.
+
+```
+node.default['fb_sudo']['defaults']['timestamp_type'] = 'global'
+node.default['fb_sudo']['defaults']['env_reset'] = true
+```
+
+Would result in the following values being added to Defaults:
+
+```
+timestamp_type=global,env_reset
+```
+
+The defaults correlate to the RHEL defaults.
+
+Default overrides can be specified using `default_overrides` like so:
+
+```
+node.default['fb_sudo']['defaults']['log_output'] = true
+node.default['fb_sudo']['default_overrides']['!/usr/bin/sudoreplay'] =
+  '!log_output'
+```
+
+which renders like this:
+
+```
+Defaults log_output
+Defaults!/usr/bin/sudoreplay !log_output
+```
+
+### Aliases
+This is the thinnest wrapper possible. Simply add aliases as you would in
+`/etc/sudoers`, but don't worry about upcasing alias names, we do that for you:
+
+```
+node.default['fb_sudo']['aliases']['command']['printing'] = '/usr/sbin/lpc, /usr/bin/lprm'
+```
+
+Will render as:
+
+```
+Cmnd_Alias PRINTING = /usr/sbin/lpc, /usr/bin/lprm
+```
+
+We recommend keeping alias names as all-lower-case for easier typing and
+predictably modifying later in the runlist.
+
+### Users
+Users work the same as aliases - just a simple mapping:
+
+```
+node.default['fb_sudo']['users']['johnsmith'] = 'ALL=NOPASSWD: ALL'
+```

--- a/cookbooks/fb_sudo/README.md
+++ b/cookbooks/fb_sudo/README.md
@@ -33,14 +33,14 @@ value is either bool or a string. If it's a bool then the default will be
 represented as `key` or `!key` as appropriate. If it's a string, then it will
 represented as `key=val`. E.g.
 
-```
+```ruby
 node.default['fb_sudo']['defaults']['timestamp_type'] = 'global'
 node.default['fb_sudo']['defaults']['env_reset'] = true
 ```
 
 Would result in the following values being added to Defaults:
 
-```
+```text
 timestamp_type=global,env_reset
 ```
 
@@ -48,7 +48,7 @@ The defaults correlate to the RHEL defaults.
 
 Default overrides can be specified using `default_overrides` like so:
 
-```
+```ruby
 node.default['fb_sudo']['defaults']['log_output'] = true
 node.default['fb_sudo']['default_overrides']['!/usr/bin/sudoreplay'] =
   '!log_output'
@@ -56,7 +56,7 @@ node.default['fb_sudo']['default_overrides']['!/usr/bin/sudoreplay'] =
 
 which renders like this:
 
-```
+```text
 Defaults log_output
 Defaults!/usr/bin/sudoreplay !log_output
 ```
@@ -65,13 +65,13 @@ Defaults!/usr/bin/sudoreplay !log_output
 This is the thinnest wrapper possible. Simply add aliases as you would in
 `/etc/sudoers`, but don't worry about upcasing alias names, we do that for you:
 
-```
+```ruby
 node.default['fb_sudo']['aliases']['command']['printing'] = '/usr/sbin/lpc, /usr/bin/lprm'
 ```
 
 Will render as:
 
-```
+```text
 Cmnd_Alias PRINTING = /usr/sbin/lpc, /usr/bin/lprm
 ```
 
@@ -79,8 +79,12 @@ We recommend keeping alias names as all-lower-case for easier typing and
 predictably modifying later in the runlist.
 
 ### Users
-Users work the same as aliases - just a simple mapping:
+Users work similar to Aliases, but with an additional level of hashing
+so you can have multiple entries:
 
-```
-node.default['fb_sudo']['users']['johnsmith'] = 'ALL=NOPASSWD: ALL'
+```ruby
+node.default['fb_sudo']['users']['johnsmith'] = {
+  'all the stuff' => 'ALL=ALL ALL'
+  'some passwordleess stuff' => 'ALL=ALL NOPASSWD: /sbin/reboot',
+}
 ```

--- a/cookbooks/fb_sudo/attributes/default.rb
+++ b/cookbooks/fb_sudo/attributes/default.rb
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2019-present, Vicarious, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['fb_sudo'] = {
+  'aliases' => {
+    'host' => {},
+    'user' => {},
+    'command' => {},
+    'runas' => {},
+  },
+  'defaults' => {
+    'visiblepw' => false,
+    'always_set_home' => true,
+    'env_reset' => true,
+    'env_keep' => 'COLORS DISPLAY HOSTNAME HISTSIZE INPUTRC KDEDIR LS_COLORS ' +
+      'MAIL PS1 PS2 QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE ' +
+      'LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES ' +
+      'LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE ' +
+      'LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY',
+    'secure_path' => '/sbin:/bin:/usr/sbin:/usr/bin',
+  },
+  'default_overrides' => {},
+  'users' => {
+    '%sudo' => 'ALL=(ALL) ALL',
+  },
+}

--- a/cookbooks/fb_sudo/attributes/default.rb
+++ b/cookbooks/fb_sudo/attributes/default.rb
@@ -35,6 +35,8 @@ default['fb_sudo'] = {
   },
   'default_overrides' => {},
   'users' => {
-    '%sudo' => 'ALL=(ALL) ALL',
+    '%sudo' => {
+      'all' => 'ALL=(ALL) ALL',
+    },
   },
 }

--- a/cookbooks/fb_sudo/metadata.rb
+++ b/cookbooks/fb_sudo/metadata.rb
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2019-present, Vicarious, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name 'fb_sudo'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'Apache-2.0'
+description 'Configures sudo'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+# never EVER change this number, ever.
+version '0.1.0'
+supports 'centos'
+supports 'debian'
+supports 'ubuntu'

--- a/cookbooks/fb_sudo/recipes/default.rb
+++ b/cookbooks/fb_sudo/recipes/default.rb
@@ -1,0 +1,36 @@
+#
+# Cookbook:: fb_sudo
+# Recipe:: default
+#
+# Copyright (c) 2019-present, Vicarious, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package 'sudo' do
+  action :upgrade
+end
+
+template '/etc/sudoers' do
+  source 'sudoers.erb'
+  mode '0440'
+  owner 'root'
+  group 'root'
+  verify 'visudo -c -q -f %{path}'
+end
+
+directory '/etc/sudoers.d' do
+  action :delete
+  recursive true
+end

--- a/cookbooks/fb_sudo/templates/sudoers.erb
+++ b/cookbooks/fb_sudo/templates/sudoers.erb
@@ -39,6 +39,9 @@ Cmnd_Alias <%= name.upcase -%> = <%= list %>
 <% end -%>
 
 # Users
-<% sudo['users'].sort.each do |user, spec| %>
-<%=  user -%> <%= spec %>
+<% sudo['users'].sort.each do |user, specs| %>
+<%   specs.each do |sname, spec| %>
+## <%= sname %>
+<%=    user -%> <%= spec %>
+<%   end -%>
 <% end -%>

--- a/cookbooks/fb_sudo/templates/sudoers.erb
+++ b/cookbooks/fb_sudo/templates/sudoers.erb
@@ -1,0 +1,44 @@
+# This file is managed by Chef
+
+<% sudo = node['fb_sudo'].to_hash -%>
+<% sudo['defaults'].each do |key, val| %>
+<%   rendered_val = '' %>
+<%   if val.is_a?(TrueClass) %>
+<%     rendered_val = key %>
+<%   elsif val.is_a?(FalseClass) %>
+<%     rendered_val = "!#{key}" %>
+<%   elsif val.is_a?(String) %>
+<%     rendered_val = "#{key}=\"#{val}\"" %>
+<%   end %>
+Defaults <%= rendered_val %>
+<% end %>
+
+<% sudo['default_overrides'].each do |key, val| %>
+Defaults<%= key %> <%= val %>
+<% end %>
+
+# Host aliases
+<% aliases = sudo['aliases'] %>
+<% aliases['host'].sort.each do |name, list| %>
+Host_Alias <%= name.upcase -%> = <%= list %>
+<% end -%>
+
+# User aliases
+<% aliases['user'].sort.each do |name, list| %>
+User_Alias <%= name.upcase -%> = <%= list %>
+<% end -%>
+
+# User aliases
+<% aliases['runas'].sort.each do |name, list| %>
+Runas_Alias <%= name.upcase -%> = <%= list %>
+<% end -%>
+
+# Command aliases
+<% aliases['command'].sort.each do |name, list| %>
+Cmnd_Alias <%= name.upcase -%> = <%= list %>
+<% end -%>
+
+# Users
+<% sudo['users'].sort.each do |user, spec| %>
+<%=  user -%> <%= spec %>
+<% end -%>


### PR DESCRIPTION
This cookbook manages `/etc/sudoers` using an FB-style attribute-driven
API.