### PR TITLE
fb_apt: Make security mirror configurable, fix security wholes

### DIFF
--- a/cookbooks/fb_apt/attributes/default.rb
+++ b/cookbooks/fb_apt/attributes/default.rb
@@ -18,19 +18,22 @@
 
 if node.debian?
   mirror = 'http://httpredir.debian.org/debian'
+  security_mirror = 'http://security.debian.org/'
   # on Debian the base keys are provided by the debian-archive-keyring package
   # and stored in a separate keyring, so there's no need to manage them here
   keys = {}
 elsif node.ubuntu?
   mirror = 'http://archive.ubuntu.com/ubuntu'
+  security_mirror = 'http://security.ubuntu.org/ubuntu'
   # Ubuntu Archive signing keys -- these are provided by the ubuntu-keyring
   # package and merged into the main keyring, we list them here so they don't
   # get clobbered
   keys = {
-    '437D05B5' => nil,
-    'FBB75451' => nil,
-    'C0B21F32' => nil,
-    'EFE21092' => nil,
+    '40976EAF437D05B5' => nil,
+    '46181433FBB75451' => nil,
+    '3B4FE6ACC0B21F32' => nil,
+    'D94AA3F0EFE21092' => nil,
+    '0BFB847F3F272F5B' => nil,
   }
 end
 
@@ -41,6 +44,7 @@ default['fb_apt'] = {
   'keyring' => '/etc/apt/trusted.gpg',
   'keyserver' => 'keys.gnupg.net',
   'mirror' => mirror,
+  'security_mirror' => security_mirror,
   'preferences' => {},
   'preserve_sources_list_d' => false,
   'update_delay' => 86400,

--- a/cookbooks/fb_apt/providers/keys.rb
+++ b/cookbooks/fb_apt/providers/keys.rb
@@ -30,13 +30,14 @@ action :run do
   if keys && keyring
     installed_keys = []
     if ::File.exist?(keyring)
-      cmd = Mixlib::ShellOut.new("LANG=C apt-key --keyring #{keyring} finger")
-      cmd.run_command
+      cmd = Mixlib::ShellOut.new(
+        "LANG=C apt-key --keyring #{keyring} finger --keyid-format long"
+      ).run_command
       cmd.error!
-      output = cmd.stdout.split("\n")
+      output = cmd.stdout.lines
       Chef::Log.debug("apt-key output: #{output.join("\n")}")
       installed_keys = output.select { |x| x.match(/(\s\w{4}){5}/) }.map do |x|
-        x[/(?<keyid>[\w]{4}\s[\w]{4})$/, 'keyid'].delete(' ')
+        x[/(?<keyid>([\w]{4}\s){3}[\w]{4})$/, 'keyid'].delete(' ')
       end
     end
     Chef::Log.debug("Installed keys: #{installed_keys.join(', ')}")

--- a/cookbooks/fb_apt/providers/sources_list.rb
+++ b/cookbooks/fb_apt/providers/sources_list.rb
@@ -24,6 +24,7 @@ use_inline_resources
 
 action :run do
   mirror = node['fb_apt']['mirror']
+  security_mirror = node['fb_apt']['security_mirror']
   distro = node['lsb']['codename']
 
   # only add base repos if mirror is set and codename is available
@@ -52,10 +53,10 @@ action :run do
     # Security updates
     if node.debian? && distro != 'sid'
       base_repos <<
-        "http://security.debian.org/ #{distro}/updates #{components_entry}"
+        "#{security_mirror} #{distro}/updates #{components_entry}"
     elsif node.ubuntu?
       base_repos <<
-        "http://security.ubuntu.com/ubuntu #{distro}-security " +
+        "#{security_mirror} #{distro}-security " +
         components_entry
     end
 


### PR DESCRIPTION
* The security mirror was hard-coded which won't work in an
  organization without outbound access
* The key management used short keyIDs which are insecure

Signed-off-by: Phil Dibowitz <phil@ipom.com>