### PR TITLE
chef: fix travis harder

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,6 +23,8 @@ platforms:
         - rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
         # we need dmidecode for the Ohai shard plugin
         - yum install -y dmidecode
+        # for some reason rsyslog fails to restart cleanly otherwise
+        - yum remove -y rsyslog
       run_command: /usr/sbin/init
   - name: ubuntu-14.04
     driver_config:

--- a/cookbooks/fb_init_sample/recipes/default.rb
+++ b/cookbooks/fb_init_sample/recipes/default.rb
@@ -64,11 +64,6 @@ include_recipe 'fb_limits'
 include_recipe 'fb_hostconf'
 include_recipe 'fb_sysctl'
 # HERE: networking
-if node.centos?
-  # We turn this off because the override causes intermittent failures in
-  # Travis when rsyslog is restarted
-  node.default['fb_syslog']['_enable_syslog_socket_override'] = false
-end
 include_recipe 'fb_syslog'
 if node.linux? && !node.container?
   include_recipe 'fb_hdparm'

--- a/cookbooks/fb_syslog/attributes/default.rb
+++ b/cookbooks/fb_syslog/attributes/default.rb
@@ -85,5 +85,4 @@ default['fb_syslog'] = {
   'rsyslog_stats_logging' => false,
   'rsyslog_use_omprog_force' => false,
   'sysconfig' => sysconfig,
-  '_enable_syslog_socket_override' => true,
 }

--- a/cookbooks/fb_syslog/recipes/packages.rb
+++ b/cookbooks/fb_syslog/recipes/packages.rb
@@ -25,7 +25,6 @@ end
 
 if node.systemd? && node.centos?
   fb_systemd_override 'override' do
-    only_if { node['fb_syslog']['_enable_syslog_socket_override'] }
     unit_name 'rsyslog.service'
     content({
               'Unit' => { 'Requires' => 'syslog.socket' },


### PR DESCRIPTION
Summary:
There is something wrong with how rsyslog is setup in the travis
docker image, try stopping it beforehand to see if that helps.

Differential Revision: D17452627

