### PR TITLE
fb_apt: redo how key management works.

### DIFF
--- a/cookbooks/fb_apt/attributes/default.rb
+++ b/cookbooks/fb_apt/attributes/default.rb
@@ -19,29 +19,14 @@
 if node.debian?
   mirror = 'http://httpredir.debian.org/debian'
   security_mirror = 'http://security.debian.org/'
-  # on Debian the base keys are provided by the debian-archive-keyring package
-  # and stored in a separate keyring, so there's no need to manage them here
-  keys = {}
 elsif node.ubuntu?
   mirror = 'http://archive.ubuntu.com/ubuntu'
   security_mirror = 'http://security.ubuntu.com/ubuntu'
-  # Ubuntu Archive signing keys -- these are provided by the ubuntu-keyring
-  # package and merged into the main keyring, we list them here so they don't
-  # get clobbered
-  keys = {
-    '40976EAF437D05B5' => nil,
-    '46181433FBB75451' => nil,
-    '3B4FE6ACC0B21F32' => nil,
-    'D94AA3F0EFE21092' => nil,
-    '0BFB847F3F272F5B' => nil,
-  }
 end
 
 default['fb_apt'] = {
   'config' => {},
   'repos' => [],
-  'keys' => keys,
-  'keyring' => '/etc/apt/trusted.gpg',
   'keyserver' => 'keys.gnupg.net',
   'mirror' => mirror,
   'security_mirror' => security_mirror,
@@ -51,4 +36,9 @@ default['fb_apt'] = {
   'want_backports' => false,
   'want_non_free' => false,
   'want_source' => false,
+  'preserve_unknown_keyrings' => false,
+  'allow_modified_pkg_keyrings' => false,
 }
+# fb_apt must be defined for this to work...
+keys = Hash[FB::Apt.get_official_keyids(node).map { |id| [id, nil] }]
+default['fb_apt']['keys'] = keys

--- a/cookbooks/fb_apt/libraries/default.rb
+++ b/cookbooks/fb_apt/libraries/default.rb
@@ -43,5 +43,92 @@ module FB
         return "\n#{indent}#{k} \"#{v}\";"
       end
     end
+
+    # Grab all keyrings owned by a package. We do not include
+    def self._get_owned_keyring_files(node)
+      Dir.glob('/etc/apt/trusted.gpg.d/*').select do |keyring|
+        cmd = dpkg("-S #{keyring}")
+        # reject this file if it isn't in a package...
+        next false if cmd.error?
+
+        # if it is in a package, double check it's not been modified
+        pkg = cmd.stdout.lines.first.split(':').first
+        cmd = dpkg("-V #{pkg}")
+        modified_files = cmd.stdout.lines.map { |line| line.split.last }
+        if modified_files.include?(keyring)
+          if node['fb_apt']['allow_modified_pkg_keyrings']
+            Chef::Log.warn(
+              "fb_apt[keys]: #{keyring} has been modified but we are still " +
+              'trusting it, do to ' +
+              'node["fb_apt"]["allow_modified_pkg_keyrings"]',
+            )
+          else
+            fail "fb_apt[keys]: keyring #{keyring} would be trusted, but " +
+              "has been modified since package (#{pkg}) was installed."
+          end
+        end
+
+        # OK, then we can accept this file
+        true
+      end
+    end
+
+    def self._run(cmd, arg)
+      Mixlib::ShellOut.new("LANC=C #{cmd} #{arg}").run_command
+    end
+
+    def self.dpkg(arg)
+      _run('dpkg', arg)
+    end
+
+    def self.aptkey(arg)
+      _run('apt-key', arg)
+    end
+
+    def self._extract_keyids(rings)
+      rings.map do |keyring|
+        cmd = aptkey("--keyring #{keyring} finger --keyid-format long")
+        cmd.error!
+        ids = cmd.stdout.lines.map do |line|
+          next unless line.start_with?('pub ')
+          line.split[1].split('/')[1]
+        end.compact
+        Chef::Log.debug(
+          "fb_apt[keys]: Keyids from #{keyring}: #{ids.join(', ')}",
+        )
+        ids
+      end.flatten
+    end
+
+    # Here ye here ye, read this before touching keys!
+    #
+    # On modern debian and ubuntu, all keys are stored in files in
+    # `/etc/apt/trusted.gpg.d/`, and **never** on `/etc/apt/trusted.gpg`,
+    # this we can know what the Distro keys are by reading all keys in
+    # all keyring files owned by packages. So what's what we populate
+    # the default list with.
+    #
+    # However, for Ubuntu <= 16.04 they are on the `/etc/apt/trusted.gpg` list,
+    # so we hard-code those, the distros are old enough they won't change.
+    def self.get_official_keyids(node)
+      if node.ubuntu? && node['platform_version'].to_i <= 16
+        return %w{
+          40976EAF437D05B5
+          46181433FBB75451
+          3B4FE6ACC0B21F32
+          D94AA3F0EFE21092
+          0BFB847F3F272F5B
+        }
+      end
+      keyids = _extract_keyids(_get_owned_keyring_files(node))
+      Chef::Log.debug("fb_apt[keys]: Official keyids: #{keyids}")
+      keyids
+    end
+
+    def self.get_installed_keyids(node)
+      rings = _get_owned_keyring_files(node)
+      rings << '/etc/apt/trusted.gpg'
+      _extract_keyids(rings)
+    end
   end
 end


### PR DESCRIPTION
[You can see https://github.com/facebook/chef-cookbooks/issues/63 for
the history here.]

This revamps the way key management works in fb_apt. It does the
following things:

* Fixes a bug where we deleted all keys because we weren't looking
at the `keys()` of the hash
* No longer tries to only look at a single keyring which does not
work reliably
* Pulls in all keyrings owned by packages and treats them as trustworthy
* Cleanups keyrings not owned by packages (configurable)
* Since we're now trusting keyrings from packages, this also validates
those files haven't been tampered with (configurable)