### PR TITLE
An attempt to fix the rsyslog instability

### DIFF
--- a/cookbooks/fb_syslog/recipes/default.rb
+++ b/cookbooks/fb_syslog/recipes/default.rb
@@ -77,4 +77,6 @@ end
 service service_name do
   action :start
   subscribes :restart, 'package[rsyslog]'
+  # within vagrant, sometimes rsyslog fails to restart the first time
+  retries 1
 end


### PR DESCRIPTION
Test on GH are regularly failing because rsyslog fails to restart.
This is an attempt to fix that.