### PR TITLE
Test all cookbooks

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -61,3 +61,4 @@ suites:
   - name: default
     run_list:
       - recipe[fb_init_sample]
+      - recipe[test_services]

--- a/cookbooks/fb_apt_cacher/recipes/default.rb
+++ b/cookbooks/fb_apt_cacher/recipes/default.rb
@@ -18,8 +18,8 @@
 # limitations under the License.
 #
 
-unless node.debian?
-  fail 'fb_apt_cacher is only supported on Debian.'
+unless node.debian? || node.ubuntu?
+  fail 'fb_apt_cacher is only supported on Debian-like Distros.'
 end
 
 package 'apt-cacher-ng' do

--- a/cookbooks/fb_init_sample/metadata.rb
+++ b/cookbooks/fb_init_sample/metadata.rb
@@ -14,45 +14,51 @@ version '0.0.1'
 }.each do |p|
   supports p
 end
-%w{
-  fb_apt
-  fb_apcupsd
-  fb_collectd
-  fb_cron
-  fb_dnsmasq
-  fb_dracut
-  fb_ebtables
-  fb_ethers
-  fb_fstab
-  fb_grub
-  fb_hdparm
-  fb_hddtemp
-  fb_helpers
-  fb_hostconf
-  fb_hosts
-  fb_ipset
-  fb_iptables
-  fb_iproute
-  fb_launchd
-  fb_ldconfig
-  fb_limits
-  fb_logrotate
-  fb_modprobe
-  fb_motd
-  fb_nsswitch
-  fb_postfix
-  fb_rpm
-  fb_rsync
-  fb_sdparm
-  fb_securetty
-  fb_storage
-  fb_swap
-  fb_sysctl
-  fb_syslog
-  fb_systemd
-  fb_timers
-  fb_tmpclean
-  fb_vsftpd
-}.each do |cb|
+[
+  'fb_apt',
+  'fb_apcupsd',
+  'fb_collectd',
+  'fb_cron',
+  'fb_dnsmasq',
+  'fb_dracut',
+  'fb_ebtables',
+  'fb_ethers',
+  'fb_fstab',
+  'fb_grub',
+  'fb_hdparm',
+  'fb_hddtemp',
+  'fb_helpers',
+  'fb_hostconf',
+  'fb_hosts',
+  # no recipe, but we want the provider included
+  # for the tests
+  'fb_ipc',
+  'fb_ipset',
+  'fb_iptables',
+  'fb_iproute',
+  'fb_launchd',
+  'fb_ldconfig',
+  'fb_limits',
+  'fb_logrotate',
+  'fb_modprobe',
+  'fb_motd',
+  'fb_nsswitch',
+  'fb_postfix',
+  'fb_rpm',
+  'fb_rsync',
+  'fb_sdparm',
+  'fb_securetty',
+  'fb_storage',
+  'fb_swap',
+  'fb_sysctl',
+  # no recipe, but we want the provider included
+  # for the tests
+  'fb_sysfs',
+  'fb_syslog',
+  'fb_systemd',
+  'fb_timers',
+  'fb_tmpclean',
+  'fb_vsftpd',
+].each do |cb|
   depends cb
 end

--- a/cookbooks/test_services/README.md
+++ b/cookbooks/test_services/README.md
@@ -1,0 +1,13 @@
+test_services Cookbook
+======================
+Simple cookbook to collect non-init services for testing
+
+Requirements
+------------
+
+Attributes
+----------
+
+Usage
+-----
+NOT MEANT FOR USAGE. Just here for our kitchen setup.

--- a/cookbooks/test_services/metadata.rb
+++ b/cookbooks/test_services/metadata.rb
@@ -1,0 +1,14 @@
+# Copyright (c) 2018-present, Facebook, Inc.
+name 'test_services'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'Apache-2.0'
+description 'Includes all cookbooks not in init for testing purposes'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.0.1'
+supports 'centos'
+depends 'fb_apache'
+depends 'fb_apt_cacher'
+depends 'fb_reprepro'
+depends 'fb_zfs'

--- a/cookbooks/test_services/recipes/default.rb
+++ b/cookbooks/test_services/recipes/default.rb
@@ -1,0 +1,12 @@
+include_recipe 'fb_apache'
+if node.debian? || node.ubuntu?
+  include_recipe 'fb_apt_cacher'
+end
+
+# Currently fb_reprepro is broken
+# https://github.com/facebook/chef-cookbooks/issues/78
+# include_recipe 'fb_reprepro'
+
+# Currently fb_zfs is broken
+# https://github.com/facebook/chef-cookbooks/issues/79
+# include_recipe 'fb_zfs'

--- a/cookbooks/test_services/recipes/default.rb
+++ b/cookbooks/test_services/recipes/default.rb
@@ -1,5 +1,5 @@
 include_recipe 'fb_apache'
-if node.debian? || node.ubuntu?
+if node.debian? || (node.ubuntu? && !node.ubuntu16?)
   include_recipe 'fb_apt_cacher'
 end
 


### PR DESCRIPTION
Currently only cookbooks referenced in the sample init are tested,
but things like apache and friends that are likely to be included
from a "tier" role/cookbook and not from init are never tested.

This adds an entry point in testing to include those so they get
tested as well.

NOTE: This is based ON #77 so both changes are in it. Will rebase after that is landed (if it works)