### PR TITLE
Fix testing instability around apt

### DIFF
--- a/cookbooks/fb_apt/providers/keys.rb
+++ b/cookbooks/fb_apt/providers/keys.rb
@@ -57,6 +57,9 @@ action :run do
         elsif keyserver
           execute "fetch and add key for keyid #{keyid} to APT" do
             command "apt-key adv --keyserver #{keyserver} --recv #{keyid}"
+            # with the DDOS against PGP Keyservers, we need to try
+            # several times
+            retries 2
           end
         else
           fail "Cannot fetch key for #{keyid} as keyserver is not defined"


### PR DESCRIPTION
Retry the key fetch to account for DDOS on keyservers.