### PR TITLE
fb_grub: lots of fixes

### DIFF
--- a/cookbooks/fb_grub/README.md
+++ b/cookbooks/fb_grub/README.md
@@ -21,6 +21,7 @@ Attributes
 * node['fb_grub']['terminal']
 * node['fb_grub']['version']
 * node['fb_grub']['use_labels']
+* node['fb_grub']['force_both_efi_and_bios']
 * node['fb_grub']['boot_disk']
 * node['fb_grub']['manage_packages']
 
@@ -62,6 +63,12 @@ If the device absolutely needs to be hardcoded, it can be overriden, as in:
 ```
 node.default['fb_grub']['boot_disk'] = 'hd1'
 ```
+
+This cookbook will, by default, write to both the EFI and BIOS locations for
+the grub config file. This can be problematic for cases were the EFI directory
+may not exist so this behavior may be disabled by setting
+`force_both_efi_and_bios` to false. This default is mostly an artifact of
+Facebook history - you probably want to disable it.
 
 ### tboot
 This cookbook optionally supports enabling tboot. This is only supported for

--- a/cookbooks/fb_grub/attributes/default.rb
+++ b/cookbooks/fb_grub/attributes/default.rb
@@ -17,10 +17,15 @@
 #
 
 version = node.centos6? ? 1 : 2
+grub2_base_dir = '/boot/grub2'
 if node.centos6? || node.redhat?
   vendor = 'redhat'
 elsif node.debian?
+  grub2_base_dir = '/boot/grub'
   vendor = 'debian'
+elsif node.ubuntu?
+  vendor = 'ubuntu'
+  grub2_base_dir = '/boot/grub'
 else
   vendor = 'centos'
 end
@@ -29,7 +34,7 @@ fb_grub = {
   '_device_hints' => [],
   '_efi_vendor_dir' => '/notdefined',
   '_grub_base_dir' => '/boot/grub',
-  '_grub2_base_dir' => '/boot/grub2',
+  '_grub2_base_dir' => grub2_base_dir,
   '_grub2_copy_path' => nil,
   '_grub2_module_path' => '/notdefined',
   '_vendor' => vendor,
@@ -65,6 +70,7 @@ fb_grub = {
   'timeout' => 5,
   'use_labels' => false,
   'version' => version,
+  'force_write_both_efi_and_bios' => true,
 }
 
 # Set the path to the grub config files

--- a/cookbooks/fb_grub/attributes/default.rb
+++ b/cookbooks/fb_grub/attributes/default.rb
@@ -70,7 +70,7 @@ fb_grub = {
   'timeout' => 5,
   'use_labels' => false,
   'version' => version,
-  'force_write_both_efi_and_bios' => true,
+  'force_both_efi_and_bios' => true,
 }
 
 # Set the path to the grub config files

--- a/cookbooks/fb_grub/providers/packages.rb
+++ b/cookbooks/fb_grub/providers/packages.rb
@@ -37,6 +37,13 @@ action :install do
       unless node.aarch64?
         packages << 'grub-pc'
       end
+    elsif node.ubuntu?
+      packages += %w{
+        grub2
+        grub2-common
+        grub-pc
+        grub-pc-bin
+      }
     else
       packages += %w{grub2-efi grub2-efi-modules grub2-tools}
       unless node.aarch64?


### PR DESCRIPTION
* Modern debians just use `/boot/grub`, not `/boot/grub2`
* Don't redefine the directory, use the central definitions
* Allow people to not right both EFI and BIOS versions which breaks
on systems without EFI dirs
* Handle the `filesystem` and `filesystem2` situation (as of 14, FS2 is
no more, it's just FS)
* when grub and grub2's dirs are the same, don't create and then delete
them
* Update fb_helpers to also handle the `filesystem` v `filesystem2`
conversion