### PR TITLE
[fb_apt] Run the apt update at the right time

### DIFF
--- a/cookbooks/fb_apt/recipes/default.rb
+++ b/cookbooks/fb_apt/recipes/default.rb
@@ -94,5 +94,5 @@ log 'periodic package cache update' do
       ::File.exist?(pkgcache) &&
       ::File.mtime(pkgcache) < Time.now - node['fb_apt']['update_delay'])
   end
-  notifies :run, 'execute[apt-get update]'
+  notifies :run, 'execute[apt-get update]', :immediately
 end


### PR DESCRIPTION
Running the update at the *end* of the run defeats the purpose.