### PR TITLE
fb_systemd: fix default_target confusion

### DIFF
--- a/cookbooks/fb_systemd/attributes/default.rb
+++ b/cookbooks/fb_systemd/attributes/default.rb
@@ -67,7 +67,7 @@ else
 end
 
 default['fb_systemd'] = {
-  'default_target' => '/lib/systemd/system/multi-user.target',
+  'default_target' => 'multi-user.target',
   'modules' => [],
   'system' => {},
   'user' => {},

--- a/cookbooks/fb_systemd/recipes/default.rb
+++ b/cookbooks/fb_systemd/recipes/default.rb
@@ -128,6 +128,13 @@ directory '/etc/systemd/user/default.target.wants' do
   mode '0755'
 end
 
-link '/etc/systemd/system/default.target' do
-  to lazy { node['fb_systemd']['default_target'] }
+execute 'set default target' do
+  not_if do
+    current = Mixlib::ShellOut.new('systemctl get-default').run_command.
+      stdout.strip
+    current != node['fb_systemd']['default_target']
+  end
+  command lazy {
+    "systemctl set-default #{node['fb_systemd']['default_target']}"
+  }
 end

--- a/cookbooks/fb_systemd/recipes/default.rb
+++ b/cookbooks/fb_systemd/recipes/default.rb
@@ -129,7 +129,7 @@ directory '/etc/systemd/user/default.target.wants' do
 end
 
 execute 'set default target' do
-  not_if do
+  only_if do
     current = Mixlib::ShellOut.new('systemctl get-default').run_command.
       stdout.strip
     current != node['fb_systemd']['default_target']

--- a/cookbooks/fb_systemd/recipes/default.rb
+++ b/cookbooks/fb_systemd/recipes/default.rb
@@ -131,7 +131,7 @@ end
 execute 'set default target' do
   only_if do
     current = Mixlib::ShellOut.new('systemctl get-default').run_command.
-      stdout.strip
+              stdout.strip
     current != node['fb_systemd']['default_target']
   end
   command lazy {


### PR DESCRIPTION
Currently there's no validation of the default target which can
render your system booting incorrectly. This fixes that.