### PR TITLE
fb_apache: various fixes

### DIFF
--- a/cookbooks/fb_apache/README.md
+++ b/cookbooks/fb_apache/README.md
@@ -41,7 +41,7 @@ syntax to a hash. So for example:
 node.default['fb_apache']['sites']['*:80'] = {
   'ServerName' => 'example.com',
   'ServerAdmin' => 'l33t@example.com',
-  'DocRoot' => '/var/www',
+  'DocumentRoot' => '/var/www',
 }
 ```
 
@@ -51,7 +51,7 @@ Will produce:
 <VirtualHost *:80>
   ServerName example.com
   ServerAdmin l33t@example.com
-  Docroot /var/www
+  DocumentRoot /var/www
 </VirtualHost>
 ```
 
@@ -82,7 +82,7 @@ This can be used for anything which repeats such as `Alias`, `ServerAlias`, or
 If the value is a hash, then the key is treated like another markup tag in the
 config and the hash is values inside that tag. For example:
 
-```
+```ruby
 node.default['fb_apache']['sites']['*:80'] = {
   'Directory /var/www' => {
     'Options' => 'Indexes FollowSymLinks MultiViews',
@@ -109,6 +109,25 @@ instead of just `Directory`).
 
 Hashes like this work for all nested tags such as `Directory` and `Location`.
 
+If you want to have more than one virtual host with the same name, you can do
+so by giving them unique names and then setting `_virtualhost`, like so:
+
+```ruby
+node.default['fb_apache']['sites']['my cool site'] = {
+  '_virtualhost' => '*:80',
+  'ServerName' => 'example.com',
+  'ServerAdmin' => 'l33t@example.com',
+  'DocumentRoot' => '/var/www/cool',
+}
+
+node.default['fb_apache']['sites']['my uncool site'] = {
+  '_virtualhost' => '*:80',
+  'ServerName' => 'anotherexample.com',
+  'ServerAdmin' => 'l33t@example.com',
+  'DocumentRoot' => '/var/www/uncool',
+}
+```
+
 #### Rewrite rules
 
 One exception to this generic 1:1 mapping is rewrite rules. Because of the
@@ -121,7 +140,7 @@ name (will be used as a comment) and the value is another hash with a
 apache, multiple conditionals in the same block will be ANDed together. To get
 OR, make an additional entry in the hash. So for example:
 
-```
+```ruby
 node.default['fb_apache']['sites']['*:80'] = {
   '_rewrites' => {
     'rewrite old thing to new thing' => {

--- a/cookbooks/fb_apache/attributes/default.rb
+++ b/cookbooks/fb_apache/attributes/default.rb
@@ -25,6 +25,34 @@ moddir = value_for_platform_family(
 
 auth_core_suffix = node.centos6? ? 'default' : 'core'
 
+modules = [
+  'alias',
+  'auth_basic',
+  'auth_digest',
+  'authn_file',
+  "authn_#{auth_core_suffix}",
+  "authz_#{auth_core_suffix}",
+  'authz_groupfile',
+  'authz_host',
+  'authz_owner',
+  'authz_user',
+  'autoindex',
+  'deflate',
+  'dir',
+  'env',
+  'headers',
+  'mime',
+  'negotiation',
+  'setenvif',
+]
+
+if node['platform_family'] == 'rhel'
+  modules += [
+    'log_config',
+    'logio',
+  ]
+end
+
 default['fb_apache'] = {
   'sysconfig' => {
     '_extra_lines' => [],
@@ -32,28 +60,7 @@ default['fb_apache'] = {
   'manage_packages' => true,
   'sites' => {},
   'extra_configs' => {},
-  'modules' => [
-    'alias',
-    'auth_basic',
-    'auth_digest',
-    'authn_file',
-    "authn_#{auth_core_suffix}",
-    "authz_#{auth_core_suffix}",
-    'authz_groupfile',
-    'authz_host',
-    'authz_owner',
-    'authz_user',
-    'autoindex',
-    'deflate',
-    'dir',
-    'env',
-    'headers',
-    'log_config',
-    'logio',
-    'mime',
-    'negotiation',
-    'setenvif',
-  ],
+  'modules' => modules,
   'modules_directory' => moddir,
   'modules_mapping' => {
     'actions' => 'mod_actions.so',

--- a/cookbooks/fb_apache/libraries/default.rb
+++ b/cookbooks/fb_apache/libraries/default.rb
@@ -53,7 +53,7 @@ module FB
       rules.each do |name, ruleset|
         buf << indentstr(1)
         buf << "# #{name}\n"
-        ruleset['conditions'].each do |cond|
+        ruleset['conditions']&.each do |cond|
           buf << indentstr(1)
           buf << "RewriteCond #{cond}\n"
         end

--- a/cookbooks/fb_apache/recipes/default.rb
+++ b/cookbooks/fb_apache/recipes/default.rb
@@ -129,7 +129,7 @@ template "#{confdir}/fb_apache.conf" do
 end
 
 # We want to collect apache stats
-template '/etc/httpd/conf.d/status.conf' do
+template "#{confdir}/status.conf" do
   source 'status.erb'
   owner 'root'
   group 'root'

--- a/cookbooks/fb_apache/templates/default/fb_sites.conf.erb
+++ b/cookbooks/fb_apache/templates/default/fb_sites.conf.erb
@@ -1,6 +1,8 @@
 # This file is controlled by Chef, do not edit!
 <% node['fb_apache']['sites'].to_hash.each do |vhost, conf| %>
-<VirtualHost <%= vhost %>>
+<% realvhost = conf['_virtualhost'] || vhost %>
+<VirtualHost <%= realvhost %>>
+<%   conf.reject! { |x, y| x == '_virtualhost' } %>
 <%=  render 'apache_conf.erb', :variables => {:conf => conf} %>
 </VirtualHost>
 


### PR DESCRIPTION
* Handle multiple vhosts of the same "name"

It's common to have various `<VirtualHost *:80>` entries, but the API
doesn't allow that. I took a page out of the Chef resource book and
tweaked the API to allow you to use a different name, but then set
the name of the virtual host with a `_virtualhost` key.

* Handle rewrite rules with no `RewriteCondition` clause

Currently if there's no `conditions` array in a `rewrite` entry the
template will crash, this fixes that.

* Handle the confdir on debian/ubuntu

Closes #84

* Don't include built-in modules on Debian/Ubuntu

Modules that are built in will cause apache to fail startup if you list
them as modules to load.

* Cleanup MD in the README.md