### PR TITLE
Fix resolved handling: enable nss-resolve opt-out

### DIFF
--- a/cookbooks/fb_systemd/README.md
+++ b/cookbooks/fb_systemd/README.md
@@ -23,6 +23,7 @@ Attributes
 * node['fb_systemd']['logind']['config']
 * node['fb_systemd']['networkd']['enable']
 * node['fb_systemd']['resolved']['enable']
+* node['fb_systemd']['resolved']['enable_nss_resolve']
 * node['fb_systemd']['resolved']['config']
 * node['fb_systemd']['timesyncd']['enable']
 * node['fb_systemd']['timesyncd']['config']
@@ -233,12 +234,13 @@ service.
 
 ### resolved configuration
 You can choose whether or not to enable `systemd-resolved` with the
-`node['fb_systemd']['resolved']['enable']` attribute, which defaults to `false`.
-Note that this will also enable the `nss-resolve` resolver in
+`node['fb_systemd']['resolved']['enable']` attribute, which defaults to
+`false`.  Note that this will also enable the `nss-resolve` resolver in
 `/etc/nsswitch.conf` in place of the glibc `dns` one (using the API provided by
-`fb_nsswitch`). Resolved can be configured using the
-`node['fb_systemd']['resolved']['config']` attribute, as described in the
-[resolved documentation](https://www.freedesktop.org/software/systemd/man/resolved.conf.html).
+`fb_nsswitch`) unless you set `enable_nss_resolve` to false. Resolved can be
+configured using the `node['fb_systemd']['resolved']['config']` attribute, as
+described in the [resolved
+documentation](https://www.freedesktop.org/software/systemd/man/resolved.conf.html).
 
 Note that this cookbook does not manage `/etc/resolv.conf`. If you're using
 resolved, you probably want to make that a symlink to

--- a/cookbooks/fb_systemd/attributes/default.rb
+++ b/cookbooks/fb_systemd/attributes/default.rb
@@ -59,10 +59,12 @@ if node.ubuntu? &&
    FB::Version.new(node['platform_version']) >= FB::Version.new('18.04')
   enable_networkd = true
   enable_resolved = true
+  enable_nss_resolve = true
   enable_timesyncd = true
 else
   enable_networkd = false
   enable_resolved = false
+  enable_nss_resolve = false
   enable_timesyncd = false
 end
 
@@ -103,6 +105,7 @@ default['fb_systemd'] = {
   },
   'resolved' => {
     'enable' => enable_resolved,
+    'enable_nss_resolve' => enable_nss_resolve,
     'config' => {},
   },
   'timesyncd' => {

--- a/cookbooks/fb_systemd/recipes/default.rb
+++ b/cookbooks/fb_systemd/recipes/default.rb
@@ -131,7 +131,7 @@ end
 execute 'set default target' do
   only_if do
     current = Mixlib::ShellOut.new('systemctl get-default').run_command.
-              stdout.strip
+      stdout.strip
     current != node['fb_systemd']['default_target']
   end
   command lazy {

--- a/cookbooks/fb_systemd/recipes/default.rb
+++ b/cookbooks/fb_systemd/recipes/default.rb
@@ -131,7 +131,7 @@ end
 execute 'set default target' do
   only_if do
     current = Mixlib::ShellOut.new('systemctl get-default').run_command.
-      stdout.strip
+              stdout.strip
     current != node['fb_systemd']['default_target']
   end
   command lazy {

--- a/cookbooks/fb_systemd/recipes/resolved.rb
+++ b/cookbooks/fb_systemd/recipes/resolved.rb
@@ -36,7 +36,10 @@ end
 # to place the resolver between mymachines and myhostname as recommended by
 # upstream.
 ruby_block 'enable nss-resolve' do
-  only_if { node['fb_systemd']['resolved']['enable'] }
+  only_if do
+    node['fb_systemd']['resolved']['enable'] &&
+    node['fb_systemd']['resolved']['enable_nss_resolve']
+  end
   block do
     node.default['fb_nsswitch']['databases']['hosts'].delete('dns')
     idx = node['fb_nsswitch']['databases']['hosts'].index('mymachines')


### PR DESCRIPTION
systemd releases before [this commit](https://github.com/systemd/systemd/pull/2031) had a non-functional `nss-resolve`. `systemd-resolved` works fine, but
not the nss plugin. Therefore binding them together doesn't work.

This provides the ability to turn off nss-resolve even when using
resolved.