### PR TITLE
Fix disable idempotency issues with journald-*

### DIFF
--- a/cookbooks/fb_systemd/recipes/journal-gatewayd.rb
+++ b/cookbooks/fb_systemd/recipes/journal-gatewayd.rb
@@ -27,6 +27,7 @@ end
 # https://github.com/chef/chef/issues/9041
 systemd_unit 'disable systemd-journal-gatewayd' do
   not_if { node['fb_systemd']['journal-gatewayd']['enable'] }
+  # ~FC009 - old version of FC...
   unit_name 'systemd-journal-gatewayd.service'
   action [:stop, :disable]
 end

--- a/cookbooks/fb_systemd/recipes/journal-gatewayd.rb
+++ b/cookbooks/fb_systemd/recipes/journal-gatewayd.rb
@@ -25,9 +25,8 @@ end
 
 # Need to use systemd_unit because of
 # https://github.com/chef/chef/issues/9041
-systemd_unit 'disable systemd-journal-gatewayd' do
+systemd_unit 'disable systemd-journal-gatewayd' do # ~FC009
   not_if { node['fb_systemd']['journal-gatewayd']['enable'] }
-  # ~FC009 - old version of FC...
   unit_name 'systemd-journal-gatewayd.service'
   action [:stop, :disable]
 end

--- a/cookbooks/fb_systemd/recipes/journal-gatewayd.rb
+++ b/cookbooks/fb_systemd/recipes/journal-gatewayd.rb
@@ -23,7 +23,7 @@ service 'systemd-journal-gatewayd' do
   action [:enable, :start]
 end
 
-# Need to use systemd_unit becuase of
+# Need to use systemd_unit because of
 # https://github.com/chef/chef/issues/9041
 systemd_unit 'disable systemd-journal-gatewayd' do
   not_if { node['fb_systemd']['journal-gatewayd']['enable'] }

--- a/cookbooks/fb_systemd/recipes/journal-gatewayd.rb
+++ b/cookbooks/fb_systemd/recipes/journal-gatewayd.rb
@@ -23,8 +23,10 @@ service 'systemd-journal-gatewayd' do
   action [:enable, :start]
 end
 
-service 'disable systemd-journal-gatewayd' do
+# Need to use systemd_unit becuase of
+# https://github.com/chef/chef/issues/9041
+systemd_unit 'disable systemd-journal-gatewayd' do
   not_if { node['fb_systemd']['journal-gatewayd']['enable'] }
-  service_name 'systemd-journal-gatewayd'
+  unit_name 'systemd-journal-gatewayd.service'
   action [:stop, :disable]
 end

--- a/cookbooks/fb_systemd/recipes/journal-remote.rb
+++ b/cookbooks/fb_systemd/recipes/journal-remote.rb
@@ -42,8 +42,10 @@ service 'systemd-journal-remote' do
   action [:enable, :start]
 end
 
-service 'disable systemd-journal-remote' do
+# Need to use systemd_unit becuase of
+# https://github.com/chef/chef/issues/9041
+systemd_unit 'disable systemd-journal-remote' do
   not_if { node['fb_systemd']['journal-remote']['enable'] }
-  service_name 'systemd-journal-remote'
+  unit_name 'systemd-journal-remote.service'
   action [:stop, :disable]
 end

--- a/cookbooks/fb_systemd/recipes/journal-remote.rb
+++ b/cookbooks/fb_systemd/recipes/journal-remote.rb
@@ -44,9 +44,8 @@ end
 
 # Need to use systemd_unit because of
 # https://github.com/chef/chef/issues/9041
-systemd_unit 'disable systemd-journal-remote' do
+systemd_unit 'disable systemd-journal-remote' do # ~FC009
   not_if { node['fb_systemd']['journal-remote']['enable'] }
-  # ~FC009 - old version of FC...
   unit_name 'systemd-journal-remote.service'
   action [:stop, :disable]
 end

--- a/cookbooks/fb_systemd/recipes/journal-remote.rb
+++ b/cookbooks/fb_systemd/recipes/journal-remote.rb
@@ -42,7 +42,7 @@ service 'systemd-journal-remote' do
   action [:enable, :start]
 end
 
-# Need to use systemd_unit becuase of
+# Need to use systemd_unit because of
 # https://github.com/chef/chef/issues/9041
 systemd_unit 'disable systemd-journal-remote' do
   not_if { node['fb_systemd']['journal-remote']['enable'] }

--- a/cookbooks/fb_systemd/recipes/journal-remote.rb
+++ b/cookbooks/fb_systemd/recipes/journal-remote.rb
@@ -46,6 +46,7 @@ end
 # https://github.com/chef/chef/issues/9041
 systemd_unit 'disable systemd-journal-remote' do
   not_if { node['fb_systemd']['journal-remote']['enable'] }
+  # ~FC009 - old version of FC...
   unit_name 'systemd-journal-remote.service'
   action [:stop, :disable]
 end


### PR DESCRIPTION
Due to https://github.com/chef/chef/issues/9041 `disable` doesn't work
on indirect units. There are only 2 so we'll use `systemd_unit` for
them.

Note that:

1. I'm ONLY changing the disable/stop units since there are
notifications against `service[$UNIT]` both in this and potentially
other cookbooks
2. Even though the resource name changing means I could drop the
explicit `unit_name`/`service_name` piece and keep the service/unit as
the resource name, doing so would break the pattern of these cookbooks,
so I didn't.