### PR TITLE
fb_apt: significant speedup; os upgrades

### DIFF
--- a/cookbooks/fb_apt/README.md
+++ b/cookbooks/fb_apt/README.md
@@ -9,6 +9,7 @@ Requirements
 Attributes
 ----------
 * node['fb_apt']['config']
+* node['fb_apt']['distro']
 * node['fb_apt']['keys']
 * node['fb_apt']['keyserver']
 * node['fb_apt']['mirror']
@@ -100,3 +101,9 @@ node.default['fb_apt']['preferences'][
     'Pin-Priority' => 450,
   })
 ```
+
+### Distro
+As mentioned above, `fb_apt` can assemble the basic sources for you. It uses
+the LSB "codename" of the current systemd to build the URLs. In the event you
+want to use Chef to upgrade across distros, however, you can set
+`node['fb_apt']['distro']` to the appropriate name and it will be used instead.

--- a/cookbooks/fb_apt/libraries/default.rb
+++ b/cookbooks/fb_apt/libraries/default.rb
@@ -66,7 +66,7 @@ module FB
         # keys that in both sets are modified keys
         modified_keys = owned_keys & modified_files
         Chef::Log.debug(
-          "fb_apt[keys]: Modofied keys from #{pkg}: #{modified_keys}",
+          "fb_apt[keys]: Modified keys from #{pkg}: #{modified_keys}",
         )
         unless modified_keys.empty?
           if node['fb_apt']['allow_modified_pkg_keyrings']

--- a/cookbooks/fb_apt/libraries/default.rb
+++ b/cookbooks/fb_apt/libraries/default.rb
@@ -61,11 +61,12 @@ module FB
       Chef::Log.debug("fb_apt[keys]: Owned keys: #{owned_keys}")
       packages.each do |pkg|
         cmd = dpkg("-V #{pkg}")
-        modified_files = Set.new(cmd.stdout.lines.map { |line| line.split.last })
+        modified_files =
+          Set.new(cmd.stdout.lines.map { |line| line.split.last })
         # keys that in both sets are modified keys
         modified_keys = owned_keys & modified_files
         Chef::Log.debug(
-          "fb_apt[keys]: Modofied keys from #{pkg}: #{modified_keys}"
+          "fb_apt[keys]: Modofied keys from #{pkg}: #{modified_keys}",
         )
         unless modified_keys.empty?
           if node['fb_apt']['allow_modified_pkg_keyrings']
@@ -73,12 +74,12 @@ module FB
               'fb_apt[keys]: The following keys have been modified but we ' +
               'are still trusting it, due to ' +
               'node["fb_apt"]["allow_modified_pkg_keyrings"]: ',
-              "#{modified_keys.to_a.join(', ')}"
+              modified_keys.to_a.join(', ').to_s,
             )
           else
-            fail "fb_apt[keys]: The following keyrings would be trusted, but " +
+            fail 'fb_apt[keys]: The following keyrings would be trusted, but ' +
               "has been modified since package (#{pkg}) was installed: " +
-              "#{modified_keys.to_a.join(', ')}"
+              modified_keys.to_a.join(', ').to_s
           end
         end
       end

--- a/cookbooks/fb_apt/providers/sources_list.rb
+++ b/cookbooks/fb_apt/providers/sources_list.rb
@@ -25,7 +25,7 @@ use_inline_resources
 action :run do
   mirror = node['fb_apt']['mirror']
   security_mirror = node['fb_apt']['security_mirror']
-  distro = node['lsb']['codename']
+  distro = node['fb_apt']['distro'] || node['lsb']['codename']
 
   # only add base repos if mirror is set and codename is available
   if mirror && distro

--- a/cookbooks/fb_apt/providers/sources_list.rb
+++ b/cookbooks/fb_apt/providers/sources_list.rb
@@ -25,6 +25,9 @@ use_inline_resources
 action :run do
   mirror = node['fb_apt']['mirror']
   security_mirror = node['fb_apt']['security_mirror']
+  # By default, we want our current distro to assemble to repo URLs.
+  # However, for when people want to upgrade across distros, we let
+  # them specify a distro to upgrade to.
   distro = node['fb_apt']['distro'] || node['lsb']['codename']
 
   # only add base repos if mirror is set and codename is available


### PR DESCRIPTION
This PR changes `fb_apt` from running a `dpkg -S` on every single
keyring, and instead runs a single one. This is significantly faster,
saving ~3 seconds on a machine with only a few keyrings.

This also allows the user to override the distro which is necessary
for instrumenting OS upgrades across distros.