### PR TITLE
fb_fstab: various fixes

### DIFF
--- a/cookbooks/fb_fstab/attributes/default.rb
+++ b/cookbooks/fb_fstab/attributes/default.rb
@@ -96,7 +96,7 @@ default['fb_fstab'] = {
     'nofail',
     # NFS sometimes automatically adds addr=<server_ip> here automagically,
     # which doesn't affect the mount, so don't compare it.
-    /^(mount)?(addr|port|proto)=.*/,
+    /^mount(addr|port|proto|vers)=|(client)?(addr|port)=.*/,
   ],
   'exclude_base_swap' => false,
 }

--- a/cookbooks/fb_fstab/libraries/default.rb
+++ b/cookbooks/fb_fstab/libraries/default.rb
@@ -25,6 +25,7 @@ module FB
       def self.determine_base_fstab_entries(full_fstab)
         core_fs_line_matching = [
           '^LABEL=(\/|\/boot|SWAP.*|\/mnt\/d\d+)\s',
+          '^\S+\s/\s',
           '^UUID=',
           '^devpts',
           '^sysfs',

--- a/cookbooks/fb_fstab/libraries/default.rb
+++ b/cookbooks/fb_fstab/libraries/default.rb
@@ -56,7 +56,7 @@ module FB
       end
 
       def self.generate_base_fstab
-        unless File.exist?(BASE_FILENAME) && File.size(BASE_FILENAME) > 0
+        unless File.exist?(BASE_FILENAME) && File.size?(BASE_FILENAME)
           FileUtils.cp('/etc/fstab', '/root/fstab.before_fb_fstab')
           FileUtils.chmod(0400, '/root/fstab.before_fb_fstab')
           full_fstab = File.read('/etc/fstab')
@@ -77,6 +77,7 @@ module FB
       # Returns an array of disks
       def self.get_in_maint_disks
         return [] unless File.exist?(IN_MAINT_DISKS_FILENAME)
+
         age = (
           Time.now - File.stat(IN_MAINT_DISKS_FILENAME).mtime
         ).to_i
@@ -92,6 +93,7 @@ module FB
         File.read(IN_MAINT_DISKS_FILENAME).each_line do |line|
           next if line.start_with?('#')
           next if line.strip.empty?
+
           disks << line.strip
         end
         unless disks.empty?
@@ -132,11 +134,7 @@ module FB
       # So we always try 2 and fail back to 1 (if 2 isn't around, then 1
       # is the new format)
       def self.get_filesystem_data(node)
-        if node['filesystem2']
-          node['filesystem2']
-        else
-          node['filesystem']
-        end
+        node['filesystem2'] || node['filesystem']
       end
 
       def self.label_to_device(label, node)
@@ -144,6 +142,7 @@ module FB
           y['label'] && y['label'] == label && !x.start_with?('/dev/block')
         end
         fail "Requested disk label #{label} doesn't exist" if d.empty?
+
         Chef::Log.debug("fb_fstab: label #{label} is device #{d.keys[0]}")
         d.keys[0]
       end
@@ -153,6 +152,7 @@ module FB
           y['uuid'] && y['uuid'] == uuid && !x.start_with?('/dev/block')
         end
         fail "Requested disk UUID #{uuid} doesn't exist" if d.empty?
+
         Chef::Log.debug("fb_fstab: uuid #{uuid} is device #{d.keys[0]}")
         d.keys[0]
       end
@@ -181,6 +181,7 @@ module FB
           next if line.strip.empty?
           # do not add swap if swap is managed elsewhere, e.g. fb_swap
           next if line.include?('swap') && node['fb_fstab']['exclude_base_swap']
+
           line_parts = line.strip.split
           line_dev_spec = line_parts[0]
 
@@ -192,6 +193,7 @@ module FB
           next if desired_mounts.any? do |_name, data|
             line_dev_spec == data['device']
           end
+
           # If that failed, we canonicalize (if possible) and try again against
           # canonicalized versions of what's in the user's config
           begin
@@ -206,26 +208,29 @@ module FB
               data['mount_point'] == line_parts[1] &&
                 data['device'].start_with?('LABEL=')
             end
+
             raise e
           end
           # If someone has a more specific mount, don't use the original
           next if desired_mounts.any? do |_name, data|
             begin
-              fs_spec == data['device'] ||
-                fs_spec == canonicalize_device(data['device'], node)
+              cdev = canonicalize_device(data['device'], node)
             rescue RuntimeError => e
               # If the entry in node['fstab']['mounts] failed to resolve,
-              # that's an error, orthogonal to what we're doing here, unless
-              # they set `allow_mount_failure`. So if it failed, raise an error,
-              # otherwise don't.
+              # that's an error, orthogonal to what we're doing here,
+              # unless they set `allow_mount_failure`. So if it failed,
+              # raise an error, otherwise don't.
               #
-              # HOWEVER, this `next` is not `next true`, because we're not
-              # skipping the mount - there was no valid comparison done. We're
-              # just moving to the next iteration of any?`
+              # HOWEVER, this `next` is not `next true`, because we're
+              # not skipping the mount - there was no valid comparison
+              # done. We're just moving to the next iteration of any?`
               next if data['allow_mount_failure']
+
               raise e
             end
+            [data['device'], cdev].include?(fs_spec)
           end
+
           case format
           when :hash
             res[fs_spec] = {

--- a/cookbooks/fb_fstab/libraries/provider.rb
+++ b/cookbooks/fb_fstab/libraries/provider.rb
@@ -180,13 +180,14 @@ module FB
           desired_device = canonicalize_device(desired_data['device'])
         rescue RuntimeError
           next if desired_data['allow_mount_failure']
+
           raise
         end
         Chef::Log.debug("fb_fstab: --> Lets see if it matches #{desired_data}")
         # if the devices are the same *and* are real devices, the
         # rest doesn't matter - we won't unmount a moved device. moves
         # option changes, etc. are all the work of the 'mount' step later.
-        if mounted_data['device'] && mounted_data['device'].start_with?('/dev/')
+        if mounted_data['device']&.start_with?('/dev/')
           if desired_device == mounted_data['device']
             Chef::Log.debug(
               "fb_fstab: Device #{mounted_data['device']} is supposed to be " +
@@ -289,7 +290,7 @@ module FB
           )
           next
         elsif dev_prefixes_to_skip.any? do |i|
-          mounted_data['device'] && mounted_data['device'].start_with?(i)
+          mounted_data['device']&.start_with?(i)
         end
           Chef::Log.debug(
             "fb_fstab: Skipping umount check for #{mounted_data['device']} " +
@@ -297,7 +298,7 @@ module FB
           )
           next
         elsif mount_prefixes_to_skip.any? do |i|
-          mounted_data['mount'] && mounted_data['mount'].start_with?(i)
+          mounted_data['mount']&.start_with?(i)
         end
           Chef::Log.debug(
             "fb_fstab: Skipping umount check for #{mounted_data['device']} " +
@@ -328,6 +329,7 @@ module FB
       if node['fb_fstab']['type_normalization_map'][type]
         return node['fb_fstab']['type_normalization_map'][type]
       end
+
       type
     end
 
@@ -361,6 +363,7 @@ module FB
       mag = val[-1].downcase
       mags = ['k', 'm', 'g', 't']
       return opt unless mags.include?(mag)
+
       num = val[0..-2].to_i
       mags.each do |d|
         num *= 1024
@@ -601,7 +604,7 @@ module FB
           if opt_list.include?('noauto')
             Chef::Log.debug(
               "fb_fstab: '#{desired_data['device']}' is configured with " +
-              "'noauto' option, we will not mount."
+              "'noauto' option, we will not mount.",
             )
             next
           end
@@ -660,8 +663,6 @@ module FB
         end
       end
     end
-
-    # rubocop:disable Style/RedundantReturn
     def _run_command_flocked(shellout, lock_file, mount_point)
       if lock_file.nil?
         return shellout.run_command
@@ -678,6 +679,5 @@ module FB
         end
       end
     end
-    # rubocop:enable Style/RedundantReturn
   end
 end

--- a/cookbooks/fb_fstab/libraries/provider.rb
+++ b/cookbooks/fb_fstab/libraries/provider.rb
@@ -546,7 +546,7 @@ module FB
       # expect. Assuming it's not NFS/Gluster which can be mounted in more than
       # once place, we look up this device and see if it moved or just isn't
       # mounted
-      unless ['nfs', 'glusterfs'].include?(desired['type'])
+      unless ['nfs', 'nfs4', 'glusterfs'].include?(desired['type'])
         device = fs_data['by_device'][desired['device']]
         if device && device['mounts'] && !device['mounts'].empty?
           Chef::Log.warn(
@@ -594,6 +594,17 @@ module FB
           Chef::Log.debug('fb_fstab: We do not change swap from fb_fstab, ' +
                           'moving on...')
           next
+        end
+
+        if desired_data['opts']
+          opt_list = desired_data['opts'].split(',')
+          if opt_list.include?('noauto')
+            Chef::Log.debug(
+              "fb_fstab: '#{desired_data['device']}' is configured with " +
+              "'noauto' option, we will not mount."
+            )
+            next
+          end
         end
 
         begin

--- a/cookbooks/fb_fstab/recipes/default.rb
+++ b/cookbooks/fb_fstab/recipes/default.rb
@@ -42,6 +42,7 @@ whyrun_safe_ruby_block 'validate data' do
         unless data['only_if'].class == Proc
           fail 'fb_fstab\'s only_if requires a Proc'
         end
+
         unless data['only_if'].call
           Chef::Log.debug("fb_fstab: Not including #{name} due to only_if")
           node.rm('fb_fstab', 'mounts', name)
@@ -79,7 +80,7 @@ whyrun_safe_ruby_block 'validate data' do
         is_systemd_automount = opt_list.include?('x-systemd.automount')
       end
       unless ['nfs', 'nfs4', 'glusterfs', 'nfusr'].include?(
-        data['type']
+        data['type'],
       ) || is_bind_mount
         if uniq_devs[data['device']]
           fail 'Device names must be unique and you have repeated ' +

--- a/cookbooks/fb_fstab/resources/default.rb
+++ b/cookbooks/fb_fstab/resources/default.rb
@@ -26,14 +26,17 @@ end
 
 action_class do
   def reload_filesystems
-    ohai 'reload filesystems for fb_fstab' do
+    # this should not trigger the parent resource as an 'update' because
+    # we are not changing anything here
+    t = build_resource(:ohai, 'reload filesystems for fb_fstab') do
       if node['filesystem2']
         plugin 'filesystem2'
       else
         plugin 'filesystem'
       end
       action :nothing
-    end.run_action(:reload)
+    end
+    t.run_action(:reload)
   end
 end
 

--- a/cookbooks/fb_fstab/spec/labels_spec.rb
+++ b/cookbooks/fb_fstab/spec/labels_spec.rb
@@ -24,8 +24,6 @@ def ohai(key)
     File.read(File.expand_path("#{key}.json", File.dirname(__FILE__))),
   )
 end
-
-# rubocop:disable LineLength
 base_contents = <<EOF
 LABEL=/ / ext4 defaults,discard 1 1
 LABEL=/boot /boot ext3    defaults        1 2
@@ -35,7 +33,6 @@ sysfs                   /sys                    sysfs   defaults        0 0
 proc                    /proc                   proc    defaults        0 0
 tmpfs /dev/shm tmpfs defaults,size=4G 0 0
 EOF
-# rubocop:enable LineLength
 
 recipe 'fb_fstab::default', :unsupported => [:mac_os_x] do |tc|
   let(:base_fstab_minimal) { base_contents }

--- a/cookbooks/fb_fstab/spec/public_spec.rb
+++ b/cookbooks/fb_fstab/spec/public_spec.rb
@@ -62,8 +62,8 @@ EOF
     it 'should not regenerate base fstab' do
       File.should_receive(:exist?).with(FB::Fstab::BASE_FILENAME).
         and_return(true)
-      File.should_receive(:size).with(FB::Fstab::BASE_FILENAME).
-        and_return(12)
+      File.should_receive(:size?).with(FB::Fstab::BASE_FILENAME).
+        and_return(true)
       File.should_not_receive(:open)
       FB::Fstab.generate_base_fstab
     end

--- a/cookbooks/fb_fstab/spec/public_spec.rb
+++ b/cookbooks/fb_fstab/spec/public_spec.rb
@@ -31,7 +31,6 @@ describe 'FB::Fstab' do
       'filesystem'
     end
   end
-  # rubocop:disable LineLength
   full_contents = <<EOF
 #
 # /etc/fstab
@@ -58,7 +57,6 @@ sysfs                   /sys                    sysfs   defaults        0 0
 proc                    /proc                   proc    defaults        0 0
 tmpfs /dev/shm tmpfs defaults,size=4G 0 0
 EOF
-  # rubocop:enable LineLength
 
   context 'generate_base_fstab' do
     it 'should not regenerate base fstab' do
@@ -73,9 +71,9 @@ EOF
       File.should_receive(:exist?).with(FB::Fstab::BASE_FILENAME).
         and_return(false)
       FileUtils.should_receive(:cp).and_return(nil)
-      FileUtils.should_receive(:chmod).and_return([
-        '/root/fstab.before_fb_fstab',
-      ])
+      FileUtils.should_receive(:chmod).and_return(
+        ['/root/fstab.before_fb_fstab'],
+      )
       File.should_receive(:read).and_return(full_contents)
       File.should_receive(:write).with(FB::Fstab::BASE_FILENAME, base_contents)
       FB::Fstab.generate_base_fstab
@@ -379,7 +377,6 @@ end
 describe 'FB::FstabProvider', :include_provider do
   include FB::FstabProvider
 
-  # rubocop:enable LineLength
   let(:node) { Chef::Node.new }
   let(:attr_name) do
     if node['filesystem2']

--- a/cookbooks/fb_fstab/spec/uuids_spec.rb
+++ b/cookbooks/fb_fstab/spec/uuids_spec.rb
@@ -18,8 +18,6 @@
 require './spec/spec_helper'
 require_relative '../libraries/default'
 require_relative '../libraries/provider'
-
-# rubocop:disable LineLength
 base_contents = <<EOF
 UUID=28137926-9c39-44c0-90d3-3b158fc97ff9 /                       ext4    defaults,discard 1 1
 UUID=9ebfe8b9-c188-4cda-8383-393deb0ac59c /boot                   ext3    defaults        1 2
@@ -29,7 +27,6 @@ sysfs                   /sys                    sysfs   defaults        0 0
 proc                    /proc                   proc    defaults        0 0
 tmpfs /dev/shm tmpfs defaults,size=4G 0 0
 EOF
-# rubocop:enable LineLength
 
 def ohai(key)
   JSON.parse(
@@ -64,18 +61,16 @@ recipe 'fb_fstab::default', :unsupported => [:mac_os_x] do |tc|
 
     it 'should include entries which pass only_if' do
       chef_run.converge(described_recipe) do |node|
-        # rubocop:disable UselessComparison
-        # rubocop:disable YodaCondition
         node.default['fb_fstab']['mounts']['tmpfs'] = {
+          # rubocop:disable UselessComparison
           'only_if' => proc { 3 == 3 },
+          # rubocop:enable UselessComparison
           'device' => 'tmpfs',
           'mount_point' => '/dev/shm',
           'type' => 'tmpfs',
           'opts' => 'defaults,size=1G',
           'pass' => 0,
         }
-        # rubocop:enable UselessComparison
-        # rubocop:enable YodaCondition
       end
       expect(chef_run).to render_file('/etc/fstab').
         with_content(tc.fixture('fstab_1Gtmpfs'))
@@ -83,7 +78,6 @@ recipe 'fb_fstab::default', :unsupported => [:mac_os_x] do |tc|
 
     it 'should not include entries which fail only_if' do
       chef_run.converge(described_recipe) do |node|
-        # rubocop:disable YodaCondition
         node.default['fb_fstab']['mounts']['thing'] = {
           'only_if' => proc { 3 == 4 },
           'device' => 'thing',
@@ -92,7 +86,6 @@ recipe 'fb_fstab::default', :unsupported => [:mac_os_x] do |tc|
           'opts' => 'size=36G',
           'pass' => 0,
         }
-        # rubocop:enable YodaCondition
       end
       expect(chef_run).to render_file('/etc/fstab').
         with_content(tc.fixture('fstab'))

--- a/cookbooks/fb_fstab/spec/uuids_spec.rb
+++ b/cookbooks/fb_fstab/spec/uuids_spec.rb
@@ -62,9 +62,7 @@ recipe 'fb_fstab::default', :unsupported => [:mac_os_x] do |tc|
     it 'should include entries which pass only_if' do
       chef_run.converge(described_recipe) do |node|
         node.default['fb_fstab']['mounts']['tmpfs'] = {
-          # rubocop:disable UselessComparison
-          'only_if' => proc { 3 == 3 },
-          # rubocop:enable UselessComparison
+          'only_if' => proc { true },
           'device' => 'tmpfs',
           'mount_point' => '/dev/shm',
           'type' => 'tmpfs',
@@ -79,7 +77,7 @@ recipe 'fb_fstab::default', :unsupported => [:mac_os_x] do |tc|
     it 'should not include entries which fail only_if' do
       chef_run.converge(described_recipe) do |node|
         node.default['fb_fstab']['mounts']['thing'] = {
-          'only_if' => proc { 3 == 4 },
+          'only_if' => proc { false },
           'device' => 'thing',
           'mount_point' => '/mnt/thing-tmpfs',
           'type' => 'tmpfs',


### PR DESCRIPTION
What follows is a variety of small fixes Vicarious has made to fb_fstab
while rolling it out. The Ohai one is from me, and the rest are from
@bwann.

* ohai-reload should not count as an "updated resource" here, and more
  importantly, shouldn't cause the entirety of fb_fstab to "update"
  every run, so we use `build_resource` to avoid that
* When `nfs4` is the filesystem, it should get all the same special
  "remote filesystem" treatment as `nfs`
* Whatever the `/` filesystem is needs to be considered 'core'
  filesystem. Obviously.
* Don't mount `noauto` filesystems
* Some better handling for systemd automounts