### PR TITLE
fb_systemd: networkd, resolved, and udev fixes

### DIFF
--- a/cookbooks/fb_systemd/recipes/networkd.rb
+++ b/cookbooks/fb_systemd/recipes/networkd.rb
@@ -23,6 +23,7 @@
 }.each do |svc|
   service svc do
     only_if { node['fb_systemd']['networkd']['enable'] }
+    subscribes :restart, 'package[systemd packages]', :immediately
     action [:enable, :start]
   end
 

--- a/cookbooks/fb_systemd/recipes/resolved.rb
+++ b/cookbooks/fb_systemd/recipes/resolved.rb
@@ -35,7 +35,7 @@ end
 # resolver and is required for systemd-resolved to work. This block attempts
 # to place the resolver between mymachines and myhostname as recommended by
 # upstream.
-ruby_block 'enable nss-resolve' do
+whyrun_safe_ruby_block 'enable nss-resolve' do
   only_if do
     node['fb_systemd']['resolved']['enable'] &&
     node['fb_systemd']['resolved']['enable_nss_resolve']
@@ -60,6 +60,7 @@ end
 
 service 'systemd-resolved' do
   only_if { node['fb_systemd']['resolved']['enable'] }
+  subscribes :restart, 'package[systemd packages]', :immediately
   action [:enable, :start]
 end
 

--- a/cookbooks/fb_systemd/recipes/udevd.rb
+++ b/cookbooks/fb_systemd/recipes/udevd.rb
@@ -58,7 +58,11 @@ template '/etc/udev/udev.conf' do
   notifies :run, 'execute[reload udev]', :immediately
 end
 
-template '/etc/udev/rules.d/00-chef.rules' do
+file '/etc/udev/rules.d/00-chef.rules' do
+  action :delete
+end
+
+template '/etc/udev/rules.d/99-chef.rules' do
   source 'rules.erb'
   owner 'root'
   group 'root'


### PR DESCRIPTION
* fb_systemd doesn't reload the right daemons when the packages are
upgraded
* fb_systemd lays down an udev rules file that is overridden by
everything else
* Don't claim you're updating resources when you're not