### PR TITLE
Fix fb_ethers by installing net-tools

### DIFF
--- a/cookbooks/fb_ethers/recipes/default.rb
+++ b/cookbooks/fb_ethers/recipes/default.rb
@@ -18,6 +18,10 @@
 # limitations under the License.
 #
 
+package 'net-tools' do
+  action :upgrade
+end
+
 template '/etc/ethers' do
   source 'ethers.erb'
   owner 'root'


### PR DESCRIPTION
Needed for `arp` command.

Signed-off-by: Phil Dibowitz <phil@ipom.com>