### PR TITLE
[fb_dnsmasq] Don't do a full restart when unnecessary

### DIFF
--- a/cookbooks/fb_dnsmasq/recipes/default.rb
+++ b/cookbooks/fb_dnsmasq/recipes/default.rb
@@ -38,8 +38,8 @@ end
 service 'dnsmasq' do
   only_if { node['fb_dnsmasq']['enable'] }
   action [:enable, :start]
-  subscribes :restart, 'template[/etc/hosts]'
-  subscribes :restart, 'template[/etc/ethers]'
+  subscribes :reload, 'template[/etc/hosts]'
+  subscribes :reload, 'template[/etc/ethers]'
 end
 
 service 'disable dnsmasq' do


### PR DESCRIPTION
For `/etc/hosts` and `/etc/ethers` updates, you can simply HUP
dnsmasq rather than restart it.