### PR TITLE
Fix specs

### DIFF
--- a/scripts/run_chefspec
+++ b/scripts/run_chefspec
@@ -59,6 +59,11 @@ for arg in "$@"; do
   newarg="$newarg $(realpath "$arg")"
 done
 
+# no arguments were passed in, run all specs
+if [ -z "$newarg" ]; then
+  newarg='cookbooks/*/spec/*_spec.rb'
+fi
+
 if [ -z "$TEST" ]; then
   # shellcheck disable=SC2086
   $RSPEC $COLOR --format=d $newarg


### PR DESCRIPTION
The `run_specs` script, if passed no arguments, doesn't pass enough to `rspec` for it to find any tess to run. So, in that case, we just pass it the right glob.