### PR TITLE
fb_apt: Handle too-new gpg2

### DIFF
--- a/cookbooks/fb_apt/recipes/default.rb
+++ b/cookbooks/fb_apt/recipes/default.rb
@@ -64,7 +64,18 @@ template '/etc/apt/preferences' do
   mode '0644'
 end
 
+execute 'check keyring format' do
+  only_if 'file /etc/apt/trusted.gpg | grep -q keybox'
+  command '
+    gpg --no-default-keyring --keyring /etc/apt/trusted.gpg --export \
+      > /etc/apt/.chef-trusted-export
+    mv /etc/apt/.chef-trusted-export /etc/apt/trusted.gpg
+  '
+  action :nothing
+end
+
 fb_apt_keys 'process keys' do
+  notifies :run, 'execute[check keyring format]', :immediately
   notifies :run, 'execute[apt-get update]'
 end
 


### PR DESCRIPTION
In the event that you don't have an `/etc/apt/trusted.gpg`, then when
`apt-key` calls `gpg` to make one, newer gpg will make it in the newer
`keybox` format, instead of the old `keyring` format. This is unreadable
by `apt`, and thus will break apt on the box.

How can this happen? When using `preseed` and *all* of your repos are
custom defined, then all the keys end up as files called
`/etc/apt/trusted.gpg.d/localX.gpg` and there is no default
`trusted.gpg` until Chef comes along... and breaks apt.

This will, upon changing `trusted.gpg`, ensure it is in the right
format.