### PR TITLE
Move `get_filesystem_data` to fb_helpers

### DIFF
--- a/cookbooks/fb_helpers/README.md
+++ b/cookbooks/fb_helpers/README.md
@@ -185,6 +185,10 @@ your node.
 * `node.root_group`
    Returns the platform-specific group for the `root` account.
 
+* `node.filesystem_data`
+   Will return either `node['filesystem']` or `node['filesystem2']`, whichever
+   is the newer format.
+
 ### FB::Helpers
 The following methods are available:
 

--- a/cookbooks/fb_helpers/libraries/node_methods.rb
+++ b/cookbooks/fb_helpers/libraries/node_methods.rb
@@ -529,5 +529,17 @@ class Chef
       # if this is set, we're trying to be small and anonymous
       File.exist?('/root/quiesce')
     end
+
+    # On Linux and Mac, as of Chef 13, FS and FS2 were identical
+    # and in Chef 14, FS2 is dropped.
+    #
+    # For FreeBSD and other platforms, they become identical in late 15
+    # and FS2 is dropped in late 16
+    #
+    # So we always try 2 and fail back to 1 (if 2 isn't around, then 1
+    # is the new format)
+    def filesystem_data
+      self['filesystem2'] || self['filesystem']
+    end
   end
 end


### PR DESCRIPTION
This was a private method off in fb_fstab, but it's useful to anyone
using the `filesystem` data in Ohai - and repeated several times.

In particular, this method is needed to make `fb_storage` work on modern
Chef (PR for that coming soon).