### PR TITLE
Move fb_fstab to use fb_helpers

### DIFF
--- a/cookbooks/fb_fstab/libraries/default.rb
+++ b/cookbooks/fb_fstab/libraries/default.rb
@@ -107,7 +107,7 @@ module FB
 
       def self.get_autofs_points(node)
         autofs_points = []
-        get_filesystem_data(node)['by_pair'].to_hash.each_value do |data|
+        node.filesystem_data['by_pair'].to_hash.each_value do |data|
           autofs_points << data['mount'] if data['fs_type'] == 'autofs'
         end
         autofs_points
@@ -126,20 +126,8 @@ module FB
         false
       end
 
-      # On Linux and Mac, as of Chef 13, FS and FS2 were identical
-      # and in Chef 14, FS2 is dropped.
-      #
-      # For FreeBSD and other platforms, they become identical in late 15
-      # and FS2 is dropped in late 16
-      #
-      # So we always try 2 and fail back to 1 (if 2 isn't around, then 1
-      # is the new format)
-      def self.get_filesystem_data(node)
-        node['filesystem2'] || node['filesystem']
-      end
-
       def self.label_to_device(label, node)
-        d = get_filesystem_data(node)['by_device'].select do |x, y|
+        d = node.filesystem_data['by_device'].select do |x, y|
           y['label'] && y['label'] == label && !x.start_with?('/dev/block')
         end
         fail "Requested disk label #{label} doesn't exist" if d.empty?
@@ -149,7 +137,7 @@ module FB
       end
 
       def self.uuid_to_device(uuid, node)
-        d = get_filesystem_data(node)['by_device'].to_hash.select do |x, y|
+        d = node.filesystem_data['by_device'].to_hash.select do |x, y|
           y['uuid'] && y['uuid'] == uuid && !x.start_with?('/dev/block')
         end
         fail "Requested disk UUID #{uuid} doesn't exist" if d.empty?

--- a/cookbooks/fb_fstab/libraries/provider.rb
+++ b/cookbooks/fb_fstab/libraries/provider.rb
@@ -250,7 +250,7 @@ module FB
       # we're going to iterate over specified mounts a lot, lets dump it
       desired_mounts = node['fb_fstab']['mounts'].to_hash
 
-      fs_data = FB::Fstab.get_filesystem_data(node)
+      fs_data = node.filesystem_data
       fs_data['by_pair'].to_hash.each_value do |mounted_data|
         # ohai uses many things to populate this structure, one of which
         # is 'blkid' which gives info on devices that are not currently
@@ -409,7 +409,7 @@ module FB
       # Start with checking if it was mounted the way we would mount it
       # this is ALMOST the same as the 'is it identical' check for non-tmpfs
       # filesystems except that with tmpfs we don't treat 'auto' as equivalent
-      fs_data = FB::Fstab.get_filesystem_data(node)
+      fs_data = node.filesystem_data
       key = "#{desired['device']},#{desired['mount_point']}"
       if fs_data['by_pair'][key]
         mounted = fs_data['by_pair'][key].to_hash
@@ -494,7 +494,7 @@ module FB
       end
 
       key = "#{desired['device']},#{desired['mount_point']}"
-      fs_data = FB::Fstab.get_filesystem_data(node)
+      fs_data = node.filesystem_data
       mounted = nil
       if fs_data['by_pair'][key]
         mounted = fs_data['by_pair'][key].to_hash


### PR DESCRIPTION
This depends on #101 which moves this method to a more accessable
location, in `fb_helpers`.