### PR TITLE
fb_modprobe: lint

### DIFF
--- a/cookbooks/fb_modprobe/resources/module.rb
+++ b/cookbooks/fb_modprobe/resources/module.rb
@@ -54,6 +54,7 @@ action_class do
           Examples: "ipv6.autoconf=1", "mlx4_en.udp_rss=1"
           FAIL
         end
+
         return True
       end
     end


### PR DESCRIPTION
This makes fb_modprobe pass newer rubocop