### PR TITLE
fb_storage: support for modern chef and array-skipping

### DIFF
--- a/cookbooks/fb_storage/libraries/format_devices_provider.rb
+++ b/cookbooks/fb_storage/libraries/format_devices_provider.rb
@@ -169,6 +169,7 @@ module FB
         }
         needs_work.each do |key, val|
           next if key == :incomplete_arrays
+
           unless val.empty?
             stats['out_of_spec'] = 1
           end
@@ -238,7 +239,7 @@ module FB
           partitions.each do |p|
             storage.arrays.each do |array, info|
               if (info['members'].include?(p) ||
-                  (info['journal'] && info['journal'].include?(p))) &&
+                  (info['journal']&.include?(p))) &&
                  ['hybrid_xfs', 0].include?(info['raid_level'])
                 arrays << array
               end
@@ -292,6 +293,7 @@ module FB
           needs_work[:missing_arrays] + needs_work[:mismatched_arrays]
         ).each do |array|
           next if to_do[:arrays].include?(array)
+
           if Set.new(storage.arrays[array]['members']) <= partitions_set
             to_do[:arrays] << array
           end
@@ -323,6 +325,7 @@ module FB
             next if to_do[:arrays].include?(array)
             # we can't fill hybrid_xfs arrays
             next if info['raid_level'] == 'hybrid_xfs'
+
             if info['members'].include?(p)
               to_do[:fill_arrays][array] ||= []
               to_do[:fill_arrays][array] << p
@@ -535,6 +538,7 @@ module FB
         arrays.each do |array|
           config = storage.arrays[array]
           next if config['raid_level'] == 'hybrid_xfs'
+
           sh = FB::Storage::Handler.get_handler(array, node)
           sh.build(config)
         end
@@ -577,6 +581,7 @@ module FB
       # as we partition them
       def disable_systemd_fstab_generator
         return unless node.systemd?
+
         Chef::Log.info(
           'fb_storage: Disabling systemd fstab generator',
         )
@@ -599,6 +604,7 @@ module FB
       # put it back...
       def enable_systemd_fstab_generator
         return unless node.systemd?
+
         Chef::Log.info(
           'fb_storage: Enabling systemd fstab generator',
         )

--- a/cookbooks/fb_storage/spec/format_devices_spec.rb
+++ b/cookbooks/fb_storage/spec/format_devices_spec.rb
@@ -108,13 +108,13 @@ describe FB::Storage::FormatDevicesProvider do
                  :partitions => ['e'],
                  :arrays => ['f'],
                },
-             )).to eq(
-               {
-                 :devices => ['a', 'd'],
-                 :partitions => ['b', 'e'],
-                 :arrays => ['c', 'f'],
-               },
-             )
+      )).to eq(
+        {
+          :devices => ['a', 'd'],
+          :partitions => ['b', 'e'],
+          :arrays => ['c', 'f'],
+        },
+      )
     end
 
     it 'strips duplicates' do
@@ -129,13 +129,13 @@ describe FB::Storage::FormatDevicesProvider do
                  :partitions => ['b'],
                  :arrays => ['f'],
                },
-             )).to eq(
-               {
-                 :devices => ['a'],
-                 :partitions => ['b'],
-                 :arrays => ['c', 'f'],
-               },
-             )
+      )).to eq(
+        {
+          :devices => ['a'],
+          :partitions => ['b'],
+          :arrays => ['c', 'f'],
+        },
+      )
     end
 
     it 'handles empty arrays on either side' do
@@ -150,13 +150,13 @@ describe FB::Storage::FormatDevicesProvider do
                  :partitions => ['b'],
                  :arrays => [],
                },
-             )).to eq(
-               {
-                 :devices => ['a'],
-                 :partitions => ['b'],
-                 :arrays => ['c'],
-               },
-             )
+      )).to eq(
+        {
+          :devices => ['a'],
+          :partitions => ['b'],
+          :arrays => ['c'],
+        },
+      )
     end
   end
 

--- a/cookbooks/fb_storage/spec/format_devices_spec.rb
+++ b/cookbooks/fb_storage/spec/format_devices_spec.rb
@@ -108,13 +108,13 @@ describe FB::Storage::FormatDevicesProvider do
                  :partitions => ['e'],
                  :arrays => ['f'],
                },
-      )).to eq(
-        {
-          :devices => ['a', 'd'],
-          :partitions => ['b', 'e'],
-          :arrays => ['c', 'f'],
-        },
-      )
+             )).to eq(
+               {
+                 :devices => ['a', 'd'],
+                 :partitions => ['b', 'e'],
+                 :arrays => ['c', 'f'],
+               },
+             )
     end
 
     it 'strips duplicates' do
@@ -129,13 +129,13 @@ describe FB::Storage::FormatDevicesProvider do
                  :partitions => ['b'],
                  :arrays => ['f'],
                },
-      )).to eq(
-        {
-          :devices => ['a'],
-          :partitions => ['b'],
-          :arrays => ['c', 'f'],
-        },
-      )
+             )).to eq(
+               {
+                 :devices => ['a'],
+                 :partitions => ['b'],
+                 :arrays => ['c', 'f'],
+               },
+             )
     end
 
     it 'handles empty arrays on either side' do
@@ -150,13 +150,13 @@ describe FB::Storage::FormatDevicesProvider do
                  :partitions => ['b'],
                  :arrays => [],
                },
-      )).to eq(
-        {
-          :devices => ['a'],
-          :partitions => ['b'],
-          :arrays => ['c'],
-        },
-      )
+             )).to eq(
+               {
+                 :devices => ['a'],
+                 :partitions => ['b'],
+                 :arrays => ['c'],
+               },
+             )
     end
   end
 


### PR DESCRIPTION
Depends on #101

* Use new `node.filesystem_data` from #101
* Fix parted-size validator to handle partial fractions
* Handle `_skip` on arrays (incase one has an array controlled by something else)
* Handle ohai for newer Chef versions
* tests for new functionality
* fix existing test
* lots of lint fixes