### PR TITLE
fb_systemd: 2 minor fixes

### DIFF
--- a/cookbooks/fb_systemd/recipes/default.rb
+++ b/cookbooks/fb_systemd/recipes/default.rb
@@ -93,6 +93,11 @@ execute 'process tmpfiles' do
       map { |x| " --exclude-prefix=#{x}" }.
       join
   }
+  # it returns 65 if it had to ignore some lines, which seems to happen
+  # quite often on initial setup
+  if node.firstboot_any_phase?
+    returns [0, 65]
+  end
   action :nothing
 end
 

--- a/cookbooks/fb_systemd/recipes/networkd.rb
+++ b/cookbooks/fb_systemd/recipes/networkd.rb
@@ -24,6 +24,10 @@
   service svc do
     only_if { node['fb_systemd']['networkd']['enable'] }
     subscribes :restart, 'package[systemd packages]', :immediately
+    if svc == 'systemd-networkd.socket'
+      notifies :stop, 'service[systemd-networkd.service]', :before
+      notifies :start, 'service[systemd-networkd.service]', :immediately
+    end
     action [:enable, :start]
   end
 


### PR DESCRIPTION
* on firstboot create_tmpfiles can fail if it had to ignore things,
  so allow that return code
* handle networkd restart properly