### PR TITLE
opensource 11 more cookbooks

### DIFF
--- a/cookbooks/fb_chrony/README.md
+++ b/cookbooks/fb_chrony/README.md
@@ -1,0 +1,48 @@
+fb_chrony Cookbook
+==================
+This cookbook configures Chrony on a system.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_chrony']['config']
+* node['fb_chrony']['servers']
+* node['fb_chrony']['pools']
+* node['fb_chrony']['default_options']
+* node['fb_chrony']['leap']
+
+Usage
+-----
+Include `fb_chrony::default` to manage Chrony. Servers and pools can be
+configured via the `node['fb_chrony']['servers']` and
+`node['fb_chrony']['pools']` attributes. These can be either lists or hashes;
+in the first case, each item will have the same options, as defined in
+`node['fb_chrony']['default_options']`. In the latter, items with empty values
+will use `node['fb_chrony']['default_options']`, while the other will use the
+value specified. For example:
+
+```ruby
+node['fb_chrony']['default_options'] = %w{iburst}
+node.default['fb_chrony']['servers'] = {
+  'ntp1.example' => %w{iburst xleave},
+  'ntp2.example' => [],
+}
+node.default['fb_chrony']['pools'] = %w{
+  ntp1pool.example
+  ntp2pool.example
+end
+```
+
+will result in the following configuration:
+
+```
+server ntp1.example iburst xleave
+server ntp2.example iburst
+
+pool ntp1pool.example iburst
+pool ntp2pool.example iburst
+```
+
+Other settings can be defined in `node['fb_chrony']['config']`.

--- a/cookbooks/fb_chrony/attributes/default.rb
+++ b/cookbooks/fb_chrony/attributes/default.rb
@@ -1,0 +1,44 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server_list = %w{
+  time1.facebook.com
+  time2.facebook.com
+  time3.facebook.com
+  time4.facebook.com
+  time5.facebook.com
+}
+
+default['fb_chrony'] = {
+  'manage_packages' => true,
+  'servers' => server_list,
+  'pools' => {},
+  # https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html
+  'default_options' => %w{iburst},
+  'config' => {
+    # Record the rate at which the system clock gains/losses time.
+    'driftfile' => '/var/lib/chrony/drift',
+    # Allow the system clock to be stepped in the first three updates
+    # if its offset is larger than 1 second.
+    'makestep' => '1.0 3',
+    # Enable kernel synchronization of the real-time clock (RTC).
+    'rtcsync' => nil,
+    # Enable logging
+    'logdir' => '/var/log/chrony',
+  },
+}

--- a/cookbooks/fb_chrony/metadata.rb
+++ b/cookbooks/fb_chrony/metadata.rb
@@ -1,0 +1,10 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'fb_chrony'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'Apache-2.0'
+description 'Installs/Configures Chronyd'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+depends 'fb_helpers'

--- a/cookbooks/fb_chrony/recipes/default.rb
+++ b/cookbooks/fb_chrony/recipes/default.rb
@@ -1,0 +1,52 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Cookbook Name:: fb_chrony
+# Recipe:: default
+#
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if node.centos? || node.redhat? || node.fedora?
+  chrony_svc = 'chronyd'
+  chrony_conf = '/etc/chrony.conf'
+elsif node.debian_family?
+  chrony_svc = 'chrony'
+  chrony_conf = '/etc/chrony/chrony.conf'
+else
+  fail 'fb_chrony: unsupported platform, aborting!'
+end
+
+include_recipe 'fb_chrony::packages'
+
+directory '/var/run/chrony' do
+  owner 'chrony'
+  group 'chrony'
+  mode '0750'
+end
+
+template 'chrony.conf' do # ~FB031
+  path chrony_conf
+  source 'chrony.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :restart, 'service[chrony]'
+end
+
+service 'chrony' do
+  service_name chrony_svc
+  action [:enable, :start]
+end

--- a/cookbooks/fb_chrony/recipes/packages.rb
+++ b/cookbooks/fb_chrony/recipes/packages.rb
@@ -1,0 +1,26 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Cookbook Name:: fb_chrony
+# Recipe:: packages
+#
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package 'chrony' do
+  only_if { node['fb_chrony']['manage_packages'] }
+  action :upgrade
+  notifies :restart, 'service[chrony]'
+end

--- a/cookbooks/fb_chrony/templates/default/chrony.conf.erb
+++ b/cookbooks/fb_chrony/templates/default/chrony.conf.erb
@@ -1,0 +1,34 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See opsfiles/chef/cookbooks/core/fb_chrony
+
+<% 
+  default_opts = node['fb_chrony']['default_options'].join(' ')
+
+  if node['fb_chrony']['servers'].is_a?(Array)
+    servers = {}
+    node['fb_chrony']['servers'].each do |server|
+      servers[server] = []
+    end
+  else
+    servers = node['fb_chrony']['servers'].to_hash
+  end
+
+  if node['fb_chrony']['pools'].is_a?(Array)
+    pools = {}
+    node['fb_chrony']['pools'].each do |pool|
+      pools[pool] = []
+    end
+  else
+    pools = node['fb_chrony']['pools'].to_hash
+  end
+%>
+<% servers.each do |server, opts| -%>
+server <%= server %> <%= opts && !opts.empty? ? opts.join(' ') : default_opts %>
+<% end -%>
+<% pools.each do |pool, opts| -%>
+pool <%= pool %> <%= opts && !opts.empty? ? opts.join(' ') : default_opts %>
+<% end -%>
+
+<% node['fb_chrony']['config'].to_hash.each do |key, val| %>
+<%=  key %> <%= val %>
+<% end %>

--- a/cookbooks/fb_e2fsprogs/README.md
+++ b/cookbooks/fb_e2fsprogs/README.md
@@ -1,0 +1,21 @@
+fb_e2fsprogs Cookbook
+=====================
+This cookbook installs and configures e2fsprogs.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_e2fsprogs']['manage_packages']
+* node['fb_e2fsprogs']['e2fsck']
+* node['fb_e2fsprogs']['mke2fs']
+
+Usage
+-----
+Include `fb_e2fsprogs` to install and manage e2fsprogs. You can set the
+`node['fb_e2fsprogs']['manage_packages']` attriubute to `false` if you'd like
+to manage package install on your own.
+
+Set `node['fb_e2fsprogs']['e2fsck]` and node[`e2fsprogs']['mke2fs']` to
+customize e2fsprogs config.

--- a/cookbooks/fb_e2fsprogs/attributes/default.rb
+++ b/cookbooks/fb_e2fsprogs/attributes/default.rb
@@ -1,0 +1,101 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ext4_features = %w{
+  has_journal
+  extent
+  huge_file
+  flex_bg
+  64bit
+  dir_nlink
+  extra_isize
+}
+
+unless node.centos7?
+  ext4_features << 'metadata_csum'
+end
+
+default['fb_e2fsprogs'] = {
+  'manage_packages' => true,
+  'e2fsck' => {
+    'options' => {
+      # Prevent e2fsck from stopping boot just because the clock is wrong
+      'broken_system_clock' => false,
+    },
+  },
+  'mke2fs' => {
+    'defaults' => {
+      'base_features' => %w{
+        sparse_super
+        large_file
+        filetype
+        resize_inode
+        dir_index
+        ext_attr
+      },
+      'default_mntopts' => %w{
+        acl
+        user_xattr
+      },
+      'enable_periodic_fsck' => false,
+      'blocksize' => 4096,
+      'inode_size' => 256,
+      'inode_ratio' => 16384,
+    },
+    'fs_types' => {
+      'ext3' => {
+        'features' => %w{has_journal},
+      },
+      'ext4' => {
+        'features' => ext4_features,
+        'inode_size' => 256,
+      },
+      'small' => {
+        'blocksize' => 1024,
+        'inode_size' => 128,
+        'inode_ratio' => 4096,
+      },
+      'floppy' => {
+        'blocksize' => 1024,
+        'inode_size' => 128,
+        'inode_ratio' => 8192,
+      },
+      'big' => {
+        'inode_ratio' => 32768,
+      },
+      'huge' => {
+        'inode_ratio' => 65536,
+      },
+      'news' => {
+        'inode_ratio' => 4096,
+      },
+      'largefile' => {
+        'inode_ratio' => 1048576,
+        'blocksize' => -1,
+      },
+      'largefile4' => {
+        'inode_ratio' => 4194304,
+        'blocksize' => -1,
+      },
+      'hurd' => {
+        'blocksize' => 4096,
+        'inode_size' => 128,
+      },
+    },
+  },
+}

--- a/cookbooks/fb_e2fsprogs/libraries/default.rb
+++ b/cookbooks/fb_e2fsprogs/libraries/default.rb
@@ -1,0 +1,43 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module FB
+  # e2fsprogs utility functions
+  class E2fsprogs
+    # Internal helper function to generate e2fsprogs config entries
+    def self._gen_e2fsprogs_config(k, v, i = 0)
+      indent = ' ' * i
+      if v.is_a?(Hash)
+        s = "#{indent}#{k} = {\n"
+        v.each do |kk, vv|
+          s += self._gen_e2fsprogs_config(kk, vv, i + 2)
+        end
+        s += "}\n"
+        return s
+      elsif v.is_a?(Array)
+        return "#{indent}#{k} = #{v.join(',')}\n"
+      elsif v.is_a?(TrueClass)
+        return "#{indent}#{k} = 1\n"
+      elsif v.is_a?(FalseClass)
+        return "#{indent}#{k} = 0\n"
+      else
+        return "#{indent}#{k} = #{v}\n"
+      end
+    end
+  end
+end

--- a/cookbooks/fb_e2fsprogs/metadata.rb
+++ b/cookbooks/fb_e2fsprogs/metadata.rb
@@ -1,0 +1,14 @@
+# Copyright (c) 2019-present, Facebook, Inc.
+name 'fb_e2fsprogs'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'Apache-2.0'
+description 'Installs/Configures e2fsprogs'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+supports 'centos'
+supports 'debian'
+supports 'fedora'
+supports 'ubuntu'
+depends 'fb_helpers'

--- a/cookbooks/fb_e2fsprogs/recipes/default.rb
+++ b/cookbooks/fb_e2fsprogs/recipes/default.rb
@@ -1,0 +1,39 @@
+#
+# Cookbook Name:: fb_e2fsprogs
+# Recipe:: default
+#
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package 'e2fsprogs' do
+  only_if { node['fb_e2fsprogs']['manage_packages'] }
+  action :upgrade
+end
+
+%w{
+  e2fsck
+  mke2fs
+}.each do |cmd|
+  template "/etc/#{cmd}.conf" do
+    source 'e2fsprogs.conf.erb'
+    owner 'root'
+    group 'root'
+    mode '0644'
+    variables(
+      :command => cmd,
+    )
+  end
+end

--- a/cookbooks/fb_e2fsprogs/templates/default/e2fsprogs.conf.erb
+++ b/cookbooks/fb_e2fsprogs/templates/default/e2fsprogs.conf.erb
@@ -1,0 +1,12 @@
+# This file is maintained by Chef. Do not edit, all changes will be
+# overwritten. See fb_e2fsprogs/README.md
+<%
+  command_config = node['fb_e2fsprogs'][@command].to_hash
+  command_config.each do |section, config|
+%>
+
+[<%= section %>]
+<%  config.each do |key, val| %>
+<%=   FB::E2fsprogs._gen_e2fsprogs_config(key, val) -%>
+<%  end
+  end %>

--- a/cookbooks/fb_ethtool/README.md
+++ b/cookbooks/fb_ethtool/README.md
@@ -1,0 +1,15 @@
+fb_ethtool Cookbook
+===================
+This cookbook installs and manages the ethtool package.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_ethtool']['manage_packages']
+
+Usage
+-----
+Include `fb_ethtool` in your runlist to use it. You can opt out of package
+management by settings `node['fb_screen']['manage_packages']` to `false`.

--- a/cookbooks/fb_ethtool/attributes/default.rb
+++ b/cookbooks/fb_ethtool/attributes/default.rb
@@ -1,0 +1,21 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['fb_ethtool'] = {
+  'manage_packages' => true,
+}

--- a/cookbooks/fb_ethtool/metadata.rb
+++ b/cookbooks/fb_ethtool/metadata.rb
@@ -1,0 +1,14 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'fb_ethtool'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'Apache-2.0'
+description 'Installs/Configures fb_ethtool'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+supports 'centos'
+supports 'debian'
+supports 'fedora'
+supports 'ubuntu'
+depends 'fb_helpers'

--- a/cookbooks/fb_ethtool/recipes/default.rb
+++ b/cookbooks/fb_ethtool/recipes/default.rb
@@ -1,0 +1,26 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Cookbook Name:: fb_ethtool
+# Recipe:: default
+#
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+unless node.linux?
+  fail 'fb_ethtool: this cookbook is only supported on Linux'
+end
+
+include_recipe 'fb_ethtool::packages'

--- a/cookbooks/fb_ethtool/recipes/packages.rb
+++ b/cookbooks/fb_ethtool/recipes/packages.rb
@@ -1,0 +1,12 @@
+#
+# Cookbook Name:: fb_ethtool
+# Recipe:: packages
+#
+# Copyright 2014, Facebook
+#
+# All rights reserved - Do Not Redistribute
+#
+
+package 'ethtool' do
+  action :upgrade
+end

--- a/cookbooks/fb_grubby/README.md
+++ b/cookbooks/fb_grubby/README.md
@@ -1,0 +1,34 @@
+fb_grubby Cookbook
+==================
+A cookbook to manage GRUB configuration via grubby.
+
+Requirements
+------------
+As a first cut, this currently supports Fedora only.
+
+Attributes
+----------
+* node['fb_grubby']['manage']
+* node['fb_grubby']['kernels']
+* node['fb_grubby']['include_args']
+* node['fb_grubby']['exclude_args']
+
+Usage
+-----
+Include `fb_grubby` in your runlist.
+
+Append the arguments you want to make sure are present in the kernel
+command-line argument by adding them to `include_args`, and the ones
+you want to make sure are absent to `exclude_args`.
+
+`kernels` is pre-populated by all the kernels on the machine; to override
+you can use an array of valid paths to any kernel images. For convenience,
+`FB::Grubby.default_kernel` will find the path to the current default kernel.
+
+### Example
+
+```
+node.default['fb_grubby']['manage'] = true
+node.default['fb_grubby']['include_args'] << 'rhgb'
+node.default['fb_grubby']['include_args'] << 'quiet'
+```

--- a/cookbooks/fb_grubby/attributes/default.rb
+++ b/cookbooks/fb_grubby/attributes/default.rb
@@ -1,0 +1,24 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['fb_grubby'] = {
+  'manage' => false,
+  'kernels' => FB::Grubby.kernels,
+  'include_args' => [],
+  'exclude_args' => [],
+}

--- a/cookbooks/fb_grubby/libraries/fb_grubby_helpers.rb
+++ b/cookbooks/fb_grubby/libraries/fb_grubby_helpers.rb
@@ -1,0 +1,76 @@
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module FB
+  module Grubby
+    def self.default_kernel
+      @default_kernel ||= begin
+        res = shell_out('/usr/sbin/grubby --default-kernel')
+        return [] if res.error?
+        res.stdout.strip
+      end
+    end
+
+    def self.kernels
+      @kernels ||= begin
+        ::Dir.glob('/boot/vmlinuz-*-*.*.*').sort
+      end
+    end
+
+    def get_boot_entry(kernel_path)
+      @boot_entries ||= {}
+      @boot_entries[kernel_path] ||= begin
+        res = shell_out("/usr/sbin/grubby --info=#{kernel_path}")
+        return {} if res.error?
+        res.stdout.lines.map(&:strip).
+          map { |line| line.split('=', 2) }.to_h.
+          map do |key, val|
+            val.start_with?('"') ? [key, val[1..-2]] : [key, val.to_i]
+          end.
+          to_h
+      end
+    end
+
+    def get_add_args(boot_args, include_args)
+      # only the arguments that need to be included that are
+      # not already in boot_args
+      include_args - boot_args
+    end
+
+    def get_boot_args(kernel_path)
+      @boot_args ||= {}
+      @boot_args[kernel_path] ||=
+        get_boot_entry(kernel_path)['args'].split.to_set
+    end
+
+    def get_rm_args(boot_args, exclude_args)
+      # only the arguments that need to be excluded that are
+      # currently in boot_args
+      exclude_args & boot_args
+    end
+
+    def update_grub_cmd(kernel_path, add_args, rm_args)
+      cmd = ['/usr/sbin/grubby', '--update-kernel', kernel_path]
+      unless add_args.empty?
+        cmd << "--args=#{add_args.to_a.join(' ')}"
+      end
+      unless rm_args.empty?
+        cmd << "--remove-args=#{rm_args.to_a.join(' ')}"
+      end
+      return cmd
+    end
+  end
+end

--- a/cookbooks/fb_grubby/metadata.rb
+++ b/cookbooks/fb_grubby/metadata.rb
@@ -1,0 +1,11 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'fb_grubby'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'Apache-2.0'
+description 'Used to manage GRUB configuration'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+supports 'fedora'
+depends 'fb_helpers'

--- a/cookbooks/fb_grubby/recipes/default.rb
+++ b/cookbooks/fb_grubby/recipes/default.rb
@@ -1,0 +1,33 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Cookbook Name:: fb_grubby
+# Recipe:: default
+#
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+unless node.fedora?
+  fail 'fb_grubby is only supported on Fedora'
+end
+
+package 'grubby' do
+  only_if { node['fb_grubby']['manage'] }
+  action :upgrade
+end
+
+fb_grubby 'Manage GRUB config' do
+  only_if { node['fb_grubby']['manage'] }
+end

--- a/cookbooks/fb_grubby/resources/fb_grubby.rb
+++ b/cookbooks/fb_grubby/resources/fb_grubby.rb
@@ -1,0 +1,41 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+resource_name :fb_grubby
+default_action :manage
+
+action_class do
+  include FB::Grubby
+end
+
+action :manage do
+  exclude_args = node['fb_grubby']['exclude_args'].to_set
+  # exclude has precedence over include
+  include_args = node['fb_grubby']['include_args'].to_set - exclude_args
+
+  node['fb_grubby']['kernels'].each do |kernel_path|
+    boot_args = get_boot_args(kernel_path)
+    add_args = get_add_args(boot_args, include_args)
+    rm_args = get_rm_args(boot_args, exclude_args)
+
+    execute "update GRUB entry for #{kernel_path}" do
+      not_if { add_args.empty? && rm_args.empty? }
+      command update_grub_cmd(kernel_path, add_args, rm_args)
+    end
+  end
+end

--- a/cookbooks/fb_grubby/spec/fb_grubby_spec.rb
+++ b/cookbooks/fb_grubby/spec/fb_grubby_spec.rb
@@ -1,0 +1,37 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'chefspec'
+require_relative '../libraries/fb_grubby_helpers'
+
+describe FB::Grubby do
+  context 'When computing grubby commands' do
+    let(:grubby) { Class.new { extend FB::Grubby } }
+    it 'should only add missing arguments' do
+      expect(grubby.get_add_args(
+               ['rhgb', 'quiet'].to_set,
+               ['rhgb', 'LANG=en_US.UTF-8'].to_set,
+      )).to eq(['LANG=en_US.UTF-8'].to_set)
+    end
+    it 'should only remove existing arguments' do
+      expect(grubby.get_rm_args(
+               ['rhgb', 'quiet'].to_set,
+               ['quiet', 'LANG=en_US.UTF-8'].to_set,
+      )).to eq(['quiet'].to_set)
+    end
+  end
+end

--- a/cookbooks/fb_hostname/README.md
+++ b/cookbooks/fb_hostname/README.md
@@ -1,0 +1,17 @@
+fb_hostname Cookbook
+===============================
+Manage the system hostname.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_hostname']['hostname']
+* node['fb_hostname']['pretty_hostname']
+
+Usage
+-----
+Just include the cookbook and set the attributes for the hostname flavors you'd
+like to manage. By default these are all `nil`, which will leave them
+unmanaged.

--- a/cookbooks/fb_hostname/attributes/default.rb
+++ b/cookbooks/fb_hostname/attributes/default.rb
@@ -1,0 +1,22 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['fb_hostname'] = {
+  'hostname' => nil,
+  'pretty_hostname' => nil,
+}

--- a/cookbooks/fb_hostname/metadata.rb
+++ b/cookbooks/fb_hostname/metadata.rb
@@ -1,0 +1,15 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'fb_hostname'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'Apache-2.0'
+description 'Manage the system hostname'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+supports 'centos'
+supports 'debian'
+supports 'fedora'
+supports 'mac_os_x'
+supports 'ubuntu'
+depends 'fb_helpers'

--- a/cookbooks/fb_hostname/recipes/default.rb
+++ b/cookbooks/fb_hostname/recipes/default.rb
@@ -1,0 +1,69 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Cookbook Name:: fb_hostname
+# Recipe:: default
+#
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+unless node.linux? || node.macos?
+  fail 'fb_hostname: only Linux and MacOS are supported!'
+end
+
+execute 'set static hostname' do
+  only_if do
+    node.systemd? && node['hostnamectl'] && node['fb_hostname']['hostname'] &&
+      node['fb_hostname']['hostname'] != node['hostnamectl']['static_hostname']
+  end
+  command lazy {
+    "/bin/hostnamectl set-hostname #{node['fb_hostname']['hostname']} --static"
+  }
+end
+
+execute 'set pretty hostname' do
+  only_if do
+    node.systemd? && node['hostnamectl'] && node['fb_hostname']['pretty'] &&
+      node['fb_hostname']['pretty_hostname'] !=
+        node['hostnamectl']['pretty_hostname']
+  end
+  command lazy {
+    "/bin/hostnamectl set-hostname #{node['fb_hostname']['pretty_hostname']}" +
+    '--pretty'
+  }
+end
+
+file '/etc/hostname' do
+  only_if { node.linux? && node['fb_hostname']['hostname'] }
+  owner 'root'
+  group 'root'
+  mode '0644'
+  content lazy { node['fb_hostname']['hostname'] }
+end
+
+%w{
+  HostName
+  ComputerName
+}.each do |key|
+  execute "set #{key}" do
+    only_if do
+      node.macos? && node['fb_hostname']['hostname'] &&
+        node['fb_hostname']['hostname'] != node['hostname']
+    end
+    command lazy {
+      "/usr/sbin/scutil --set #{key} #{node['fb_hostname']['hostname']}"
+    }
+  end
+end

--- a/cookbooks/fb_less/README.md
+++ b/cookbooks/fb_less/README.md
@@ -1,0 +1,15 @@
+fb_less Cookbook
+====================
+This cookbook manages `less` and deploys a custom `lesspipe.sh`.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_less']['manage_packages']
+
+Usage
+-----
+Include `fb_less` into the relevant cookbooks. If you do not want `less` to be
+installed automatically, set `node['fb_less']['manage_packages']` to `false`.

--- a/cookbooks/fb_less/attributes/default.rb
+++ b/cookbooks/fb_less/attributes/default.rb
@@ -1,0 +1,21 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['fb_less'] = {
+  'manage_packages' => true,
+}

--- a/cookbooks/fb_less/files/default/lesspipe.sh
+++ b/cookbooks/fb_less/files/default/lesspipe.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+#
+# To use this filter with less, define LESSOPEN:
+# export LESSOPEN="|/usr/bin/lesspipe.sh %s"
+#
+# The script should return zero if the output was valid and non-zero
+# otherwise, so less could detect even a valid empty output
+# (for example while uncompressing gzipped empty file).
+# For backward-compatibility, this is not required by default. To turn
+# this functionality there should be another vertical bar (|) straight
+# after the first one in the LESSOPEN environment variable:
+# export LESSOPEN="||/usr/bin/lesspipe.sh %s"
+
+if [ ! -e "$1" ] ; then
+	exit 1
+fi
+
+if [ -d "$1" ] ; then
+	ls -alF -- "$1"
+	exit $?
+fi
+
+exec 2>/dev/null
+
+# Allow for user defined filters
+if [ -x ~/.lessfilter ]; then
+	~/.lessfilter "$1"
+	if [ $? -eq 0 ]; then
+		exit 0
+	fi
+fi
+
+manfilter ()
+{
+	if test -x /usr/bin/man ; then
+		# See rhbz#1241543 for more info.  Well, actually we firstly
+		# used 'man -l', then we switched to groff, and then we again
+		# switched back to 'man -l'.
+		/usr/bin/man -P /usr/bin/cat -l "$1"
+	elif test -x /usr/bin/groff; then
+		# This is from pre-rhbz#1241543-time.
+		groff -Tascii -mandoc "$1" | cat -s
+	else
+		echo "WARNING:"
+		echo "WARNING: to better show manual pages, install 'man-db' package"
+		echo "WARNING:"
+		cat "$1"
+	fi
+}
+
+export MAN_KEEP_FORMATTING=1
+
+case "$1" in
+*.[1-9n].bz2|*.[1-9]x.bz2|*.man.bz2|*.[1-9n].[gx]z|*.[1-9]x.[gx]z|*.man.[gx]z|*.[1-9n].lzma|*.[1-9]x.lzma|*.man.lzma|*.[1-9n].zst|*.[1-9]x.zst|*.man.zst)
+	case "$1" in
+	*.gz)		DECOMPRESSOR="gzip -dc" ;;
+	*.bz2)		DECOMPRESSOR="bzip2 -dc" ;;
+	*.xz|*.lzma)	DECOMPRESSOR="xz -dc" ;;
+	*.zst)		DECOMPRESSON="zstd -dcq" ;;
+	esac
+	if [ -n "$DECOMPRESSOR" ] && $DECOMPRESSOR -- "$1" | file - | grep -q troff; then
+		$DECOMPRESSOR -- "$1" | manfilter -
+		exit $?
+	fi ;;&
+*.[1-9n]|*.[1-9]x|*.man)
+	if file "$1" | grep -q troff; then
+		manfilter "$1"
+		exit $?
+	fi ;;&
+*.tar) tar tvvf "$1"; exit $? ;;
+*.tgz|*.tar.gz|*.tar.[zZ]) tar tzvvf "$1"; exit $? ;;
+*.tar.xz) tar Jtvvf "$1"; exit $? ;;
+*.tzst|*.tar.zst) tar -I zstd tvvf "$1"; exit $? ;;
+*.xz|*.lzma) xz -dc -- "$1"; exit $? ;;
+*.tar.bz2|*.tbz2) bzip2 -dc -- "$1" | tar tvvf -; exit $? ;;
+*.[zZ]|*.gz) gzip -dc -- "$1"; exit $? ;;
+*.bz2) bzip2 -dc -- "$1"; exit $? ;;
+*.zst) zstd -dcq -- "$1"; exit $? ;;
+*.zip|*.jar|*.nbm) zipinfo -- "$1"; exit $? ;;
+# --nomanifest -> rhbz#1450277
+*.rpm) rpm -qpivl --changelog --nomanifest -- "$1"; exit $? ;;
+*.cpi|*.cpio) cpio -itv < "$1"; exit $? ;;
+*.gpg)
+	if [ -x /usr/bin/gpg2 ]; then
+		gpg2 -d "$1"
+		exit $?
+	elif [ -x /usr/bin/gpg ]; then
+		gpg -d "$1"
+		exit $?
+	else
+		echo "No GnuPG available."
+		echo "Install gnupg2 or gnupg to show encrypted files."
+		exit 1
+	fi ;;
+*.gif|*.jpeg|*.jpg|*.pcd|*.png|*.tga|*.tiff|*.tif)
+	if [ -x /usr/bin/identify ]; then
+		identify "$1"
+		exit $?
+	elif [ -x /usr/bin/gm ]; then
+		gm identify "$1"
+		exit $?
+	else
+		echo "No identify available"
+		echo "Install ImageMagick or GraphicsMagick to browse images"
+		exit 1
+	fi ;;
+*)
+	if [ -x /usr/bin/file ] && [ -x /usr/bin/iconv ] && [ -x /usr/bin/cut ]; then
+		case `file -b "$1"` in
+		*UTF-16*) conv='UTF-16' ;;
+		*UTF-32*) conv='UTF-32' ;;
+		esac
+		if [ -n "$conv" ]; then
+			env=`echo $LANG | cut -d. -f2`
+			if [ -n "$env" -a "$conv" != "$env" ]; then
+				iconv -f $conv -t $env "$1"
+				exit $?
+			fi
+		fi
+	fi
+	exit 1
+esac

--- a/cookbooks/fb_less/files/default/profile.d/fbless.sh
+++ b/cookbooks/fb_less/files/default/profile.d/fbless.sh
@@ -1,0 +1,8 @@
+# Set some useful LESS options.  If you prefer your own, set it in
+# your shell startup script and it will be honored.
+if [ -z "${LESS+set}" ]; then
+    export LESS='-n -i'
+fi
+if [ -z "${LESSOPEN+set}" ]; then
+	export LESSOPEN='||/usr/local/bin/lesspipe.sh %s'
+fi

--- a/cookbooks/fb_less/metadata.rb
+++ b/cookbooks/fb_less/metadata.rb
@@ -1,0 +1,10 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'fb_less'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'Apache-2.0'
+description 'Configures less'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.0.1'
+depends 'fb_helpers'

--- a/cookbooks/fb_less/recipes/default.rb
+++ b/cookbooks/fb_less/recipes/default.rb
@@ -1,0 +1,39 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Cookbook Name:: fb_less
+# Recipe:: default
+#
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package 'less' do
+  only_if { node.linux? && node['fb_less']['manage_packages'] }
+  action :upgrade
+end
+
+cookbook_file '/usr/local/bin/lesspipe.sh' do
+  source 'lesspipe.sh'
+  owner 'root'
+  group 'root'
+  mode '0755'
+end
+
+cookbook_file '/etc/profile.d/fbless.sh' do
+  source 'profile.d/fbless.sh'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end

--- a/cookbooks/fb_mlocate/README.md
+++ b/cookbooks/fb_mlocate/README.md
@@ -1,0 +1,27 @@
+fb_mlocate Cookbook
+====================
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_mlocate']['want_mlocate']
+* node['fb_mlocate']['prunefs']
+* node['fb_mlocate']['prunepaths']
+
+Usage
+-----
+If you want mlocate installed (which includes our custom
+updatedb.conf), then set `node['fb_mlocate']['want_mlocate']` to true.
+
+WARNING: If `node['fb_mlocate']['want_mlocate']` is set to false
+(the default) then any existing instance of mlocate (including the conf
+file associated with the RPM) will be removed.
+
+`node['fb_mlocate']['prunefs']` contains a list of filesystem
+types to not index. It corresponds to the PRUNEFS setting from
+updatedb.conf(5)
+
+`node['fb_mlocate']['prunepaths']` is a list of paths to exclude
+from the index.  It corresponds to PRUNEPATHS from updatedb.conf(5)

--- a/cookbooks/fb_mlocate/attributes/default.rb
+++ b/cookbooks/fb_mlocate/attributes/default.rb
@@ -1,0 +1,53 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2012-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# mlocate is opt-in
+default['fb_mlocate'] = {
+  'want_mlocate' => false,
+  'prunefs' => [
+    'auto',
+    'afs',
+    'iso9660',
+    'sfs',
+    'udf',
+    'nfs',
+    'nfs4',
+    'autofs',
+    'fuse.glusterfs',
+    'fuse.nfusr',
+    'fuse.squashfuse_ll',
+    'fuse.gvfs.36',
+    'fuse.sshfs',
+    'fuse.gvfsd-fuse',
+    'fuse.deweyfs',
+  ],
+  'prunepaths' => [
+    '/home',
+    '/mnt/vol',
+    '/afs',
+    '/media',
+    '/net',
+    '/sfs',
+    '/tmp',
+    '/udev',
+    '/var/spool/cups',
+    '/var/spool/squid',
+    '/var/tmp',
+    '/hay',
+  ],
+}

--- a/cookbooks/fb_mlocate/metadata.rb
+++ b/cookbooks/fb_mlocate/metadata.rb
@@ -1,0 +1,14 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'fb_mlocate'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'Apache-2.0'
+description 'Installs/Configures mlocate'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.0.1'
+supports 'centos'
+supports 'debian'
+supports 'fedora'
+supports 'ubuntu'
+depends 'fb_helpers'

--- a/cookbooks/fb_mlocate/recipes/default.rb
+++ b/cookbooks/fb_mlocate/recipes/default.rb
@@ -1,0 +1,60 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Cookbook Name:: fb_mlocate
+# Recipe:: default
+#
+# Copyright (c) 2012-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+unless node.linux?
+  fail 'fb_mlocate: this cookbook is only supported on Linux'
+end
+
+# mlocate should be available (along with our custom updatedb.conf
+# file) if and only if it is specifically requested via
+# node['fb_mlocate']['want_mlocate']
+
+conf_path = '/etc/updatedb.conf'
+
+include_recipe 'fb_mlocate::packages'
+
+template conf_path do
+  only_if { node['fb_mlocate']['want_mlocate'] }
+  source 'updatedb.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  action :create
+end
+
+package 'remove mlocate' do
+  not_if { node['fb_mlocate']['want_mlocate'] }
+  package_name 'mlocate'
+  action :remove
+end
+
+file "remove #{conf_path}" do
+  not_if { node['fb_mlocate']['want_mlocate'] }
+  path conf_path
+  action :delete
+end
+
+# Blow away any .rpmnew or .rpmsave files
+%w{new save}.each do |suffix|
+  file "#{conf_path}.rpm#{suffix}" do
+    action :delete
+  end
+end

--- a/cookbooks/fb_mlocate/recipes/packages.rb
+++ b/cookbooks/fb_mlocate/recipes/packages.rb
@@ -1,0 +1,25 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Cookbook Name:: fb_mlocate
+# Recipe:: packages
+#
+# Copyright (c) 2012-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package 'mlocate' do
+  only_if { node['fb_mlocate']['want_mlocate'] }
+  action :upgrade
+end

--- a/cookbooks/fb_mlocate/templates/default/updatedb.conf.erb
+++ b/cookbooks/fb_mlocate/templates/default/updatedb.conf.erb
@@ -1,0 +1,5 @@
+# This file is generate by Chef.  do not modify directly.
+# You can modify it by following the instructions at
+#   opsfiles/chef/cookbooks/core/fb_mlocate/README.md
+PRUNEFS = "<%= node['fb_mlocate']['prunefs'].join(' ') %>"
+PRUNEPATHS = "<%= node['fb_mlocate']['prunepaths'].join(' ') %>"

--- a/cookbooks/fb_nscd/README.md
+++ b/cookbooks/fb_nscd/README.md
@@ -1,0 +1,39 @@
+fb_nscd Cookbook
+================
+This cookbook provides configuration of nscd. If this cookbook is in your
+runlist, you can tweak all nscd settings from within your own cookbook.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_nscd']['configs'][$KEY][$VALUE]
+* node['fb_nscd'][$TABLE][$KEY][$VALUE]
+
+Usage
+-----
+You can tweak settings for any given cache settings table (`passwd`, `group`,
+`hosts`) through `node['fb_nscd'][$TABLE][$KEY][$VALUE]`. You can also define
+global settings via ``node['fb_nscd']['configs'][$KEY][$VALUE]`. Please refer
+to the
+[upstream documentation](http://man7.org/linux/man-pages/man5/nscd.conf.5.html)
+for the available settings.
+
+So for example, to enable hosts cache, you can do:
+
+```
+node.default['fb_nscd']['hosts']['enable-cache'] = 'yes'
+```
+
+You can then change any setting for a cache such as:
+
+```
+node.default['fb_nscd']['hosts']['positive-time-to-live'] = 300
+```
+
+If a cache is not enabled, the relevant settings will not be added to the config
+file.
+
+The nscd service will be started automatically if any caches are enabled and
+explicitly stopped if no caches are enabled.

--- a/cookbooks/fb_nscd/attributes/default.rb
+++ b/cookbooks/fb_nscd/attributes/default.rb
@@ -1,0 +1,52 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2012-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# it makes sense for passwd and group to be the same settings, at least
+# for most cases.
+user_defaults = {
+  'enable-cache' => false,
+  'positive-time-to-live' => 600,
+  'negative-time-to-live' => 20,
+  'suggested-size' => 211,
+  'check-files' => true,
+  'persistent' => true,
+  'shared' => true,
+  'max-db-size' => 134217728,
+}
+
+hosts_defaults = {
+  'enable-cache' => false,
+  'positive-time-to-live' => 300,
+  'negative-time-to-live' => 0,
+  'suggested-size' => 211,
+  'check-files' => true,
+  'persistent' => true,
+  'shared' => true,
+  'max-db-size' => 33554432,
+}
+
+default['fb_nscd'] = {
+  'configs' => {
+    'server-user' => 'nscd',
+    'debug-level' => 0,
+    'paranoia' => false,
+  },
+  'passwd' => user_defaults,
+  'group' => user_defaults,
+  'hosts' => hosts_defaults,
+}

--- a/cookbooks/fb_nscd/libraries/default.rb
+++ b/cookbooks/fb_nscd/libraries/default.rb
@@ -1,0 +1,46 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2012-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module FB
+  class Nscd
+    def self.nscd_enabled?(node)
+      %w{passwd group hosts}.any? do |table|
+        node['fb_nscd'][table]['enable-cache'] == true ||
+          node['fb_nscd'][table]['enable-cache'] == 'yes'
+      end
+    end
+
+    def self._render_value(value)
+      if value.is_a?(TrueClass)
+        'yes'
+      elsif value.is_a?(FalseClass)
+        'no'
+      else
+        value.to_s
+      end
+    end
+
+    def self._global_config(property, value)
+      format('%-25s %s', property, FB::Nscd._render_value(value))
+    end
+
+    def self._table_config(property, table, value)
+      format('%-25s %-9s %-8s', property, table, FB::Nscd._render_value(value))
+    end
+  end
+end

--- a/cookbooks/fb_nscd/metadata.rb
+++ b/cookbooks/fb_nscd/metadata.rb
@@ -1,0 +1,9 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'fb_nscd'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'Apache-2.0'
+description 'Installs/Configures nscd'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.0.1'

--- a/cookbooks/fb_nscd/recipes/default.rb
+++ b/cookbooks/fb_nscd/recipes/default.rb
@@ -1,0 +1,48 @@
+#
+# Cookbook Name:: fb_nscd
+# Recipe:: default
+#
+# Copyright (c) 2012-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'fb_nscd::packages'
+
+template '/etc/nscd.conf' do
+  only_if { FB::Nscd.nscd_enabled?(node) }
+  owner 'root'
+  group 'root'
+  mode '0644'
+  source 'nscd.conf.erb'
+  notifies :restart, 'service[nscd]', :immediately
+end
+
+service 'nscd' do
+  only_if { FB::Nscd.nscd_enabled?(node) }
+  action [:enable, :start]
+  subscribes :restart, 'template[/etc/ldap.conf]', :immediately
+end
+
+service 'disable nscd' do
+  not_if { FB::Nscd.nscd_enabled?(node) }
+  service_name 'nscd'
+  action [:stop, :disable]
+end
+
+package 'remove nscd' do
+  not_if { FB::Nscd.nscd_enabled?(node) }
+  package_name 'nscd'
+  action :remove
+end

--- a/cookbooks/fb_nscd/recipes/packages.rb
+++ b/cookbooks/fb_nscd/recipes/packages.rb
@@ -1,0 +1,15 @@
+#
+# Cookbook Name:: fb_nscd
+# Recipe:: packages
+#
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright 2012, Facebook
+#
+# All rights reserved - Do Not Redistribute
+#
+
+package 'nscd' do
+  only_if { FB::Nscd.nscd_enabled?(node) }
+  action :upgrade
+end

--- a/cookbooks/fb_nscd/templates/default/nscd.conf.erb
+++ b/cookbooks/fb_nscd/templates/default/nscd.conf.erb
@@ -1,0 +1,19 @@
+# BEGIN GENERAL CONFIG
+<%- cfg = node['fb_nscd']['configs'] %>
+<%- cfg.keys.sort.each do |prop| %>
+<%=   FB::Nscd._global_config(prop, cfg[prop]) %>
+<%- end %>
+
+<%- %w{passwd group hosts}.each do |table| %>
+
+# BEGIN <%= table.upcase %> CONFIG
+<%-   cfg = node['fb_nscd'][table] %>
+<%-   if cfg['enable-cache'] == true || cfg['enable-cache'] == 'yes' %>
+<%-     cfg.keys.sort.each do |prop| %>
+<%=       FB::Nscd._table_config(prop, table, cfg[prop]) %>
+<%-     end %>
+
+<%-   else %>
+<%=     FB::Nscd._table_config('enable-cache', table, false) %>
+<%-   end %>
+<%- end %>

--- a/cookbooks/fb_screen/README.md
+++ b/cookbooks/fb_screen/README.md
@@ -1,0 +1,15 @@
+fb_screen Cookbook
+==================
+This cookbook installs and manages the `screen` package.
+
+Requirements
+------------
+
+Attributes
+----------
+* node['fb_screen']['manage_packages']
+
+Usage
+-----
+Include `fb_screen` in your runlist to use it. You can opt out of package
+management by settings `node['fb_screen']['manage_packages']` to `false`.

--- a/cookbooks/fb_screen/attributes/default.rb
+++ b/cookbooks/fb_screen/attributes/default.rb
@@ -1,0 +1,21 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['fb_screen'] = {
+  'manage_packages' => true,
+}

--- a/cookbooks/fb_screen/libraries/default.rb
+++ b/cookbooks/fb_screen/libraries/default.rb
@@ -1,0 +1,32 @@
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module FB
+  class Screen
+    def self.screen_session_active?
+      session_active = false
+      Dir.glob('/var/run/screen/**/*') do |path|
+        st = File.lstat(path)
+        # GNU screen might use a pipe or a socket, depending on how
+        # it was compiled
+        if st.pipe? || st.socket?
+          session_active = true
+        end
+      end
+      return session_active
+    end
+  end
+end

--- a/cookbooks/fb_screen/metadata.rb
+++ b/cookbooks/fb_screen/metadata.rb
@@ -1,0 +1,15 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'fb_screen'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'Apache-2.0'
+description 'Installs/Configures fb_screen'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+# never EVER change this number, ever.
+version '0.1.0'
+supports 'centos'
+supports 'debian'
+supports 'fedora'
+supports 'ubuntu'
+depends 'fb_helpers'

--- a/cookbooks/fb_screen/recipes/default.rb
+++ b/cookbooks/fb_screen/recipes/default.rb
@@ -1,0 +1,26 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Cookbook Name:: fb_screen
+# Recipe:: default
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+unless node.linux?
+  fail 'fb_screen: this cookbook is only supported on Linux'
+end
+
+include_recipe 'fb_screen::packages'

--- a/cookbooks/fb_screen/recipes/packages.rb
+++ b/cookbooks/fb_screen/recipes/packages.rb
@@ -1,0 +1,25 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Cookbook Name:: fb_screen
+# Recipe:: packages
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package 'screen' do
+  only_if { node['fb_screen']['manage_packages'] }
+  action :upgrade
+end

--- a/cookbooks/fb_sysstat/README.md
+++ b/cookbooks/fb_sysstat/README.md
@@ -1,0 +1,13 @@
+fb_sysstat Cookbook
+===================
+This cookbook installs and manages sysstat.
+
+Requirements
+------------
+
+Attributes
+----------
+
+Usage
+-----
+Include the cookbook in your recipe or runlist.

--- a/cookbooks/fb_sysstat/metadata.rb
+++ b/cookbooks/fb_sysstat/metadata.rb
@@ -1,0 +1,11 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'fb_sysstat'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'Apache-2.0'
+description 'Configuration for sysstat'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.1.0'
+supports 'centos'
+supports 'fedora'

--- a/cookbooks/fb_sysstat/recipes/cron.rb
+++ b/cookbooks/fb_sysstat/recipes/cron.rb
@@ -1,0 +1,48 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Cookbook Name:: fb_sysstat
+# Recipe:: cron
+#
+# Copyright (c) 2013-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+case node['platform_family']
+when 'rhel', 'fedora', 'suse'
+  sa_dir = '/usr/lib64/sa'
+else
+  fail "fb_sysstat: not supported on #{node['platform_family']}, aborting!"
+end
+
+{
+  'sysstat_accounting_1' => {
+    'time' => '*/10 * * * *',
+    'command' => "#{sa_dir}/sa1 -S DISK,SNMP 1 1 &> /dev/null",
+    'oncall' => 'oncall+oscore@xmail.facebook.com',
+  },
+  'sysstat_accounting_2' => {
+    'time' => '53 23 * * *',
+    'command' => "#{sa_dir}/sa2 -A &> /dev/null",
+    'oncall' => 'oncall+oscore@xmail.facebook.com',
+  },
+}.each do |k, v|
+  node.default['fb_cron']['jobs'][k] = v
+end
+
+# the sa[12] commands here trample on those defined in the
+# sysstat_accounting_[12] jobs
+file '/etc/cron.d/sysstat' do
+  action :delete
+end

--- a/cookbooks/fb_sysstat/recipes/default.rb
+++ b/cookbooks/fb_sysstat/recipes/default.rb
@@ -1,0 +1,23 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Cookbook Name:: fb_sysstat
+# Recipe:: default
+#
+# Copyright (c) 2013-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'fb_sysstat::packages'
+include_recipe 'fb_sysstat::cron'

--- a/cookbooks/fb_sysstat/recipes/packages.rb
+++ b/cookbooks/fb_sysstat/recipes/packages.rb
@@ -1,0 +1,24 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Cookbook Name:: fb_sysstat
+# Recipe:: packages
+#
+# Copyright (c) 2013-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package 'sysstat' do
+  action :upgrade
+end

--- a/cookbooks/fb_util_linux/README.md
+++ b/cookbooks/fb_util_linux/README.md
@@ -1,0 +1,19 @@
+fb_util_linux Cookbook
+==================
+This cookbook installs and manages util-linux.
+
+Requirements
+------------
+CentOS
+
+Attributes
+----------
+* node['fb_util_linux']['enable_fstrim']
+* node['fb_util_linux']['manage_packages']
+
+Usage
+-----
+This cookbook will install and manage util-linux. It will install the necessary
+packages by default; set `node['fb_util_linux']['manage_packages']` to `false`
+to opt out. By default global periodic fstrim is disabled -- it can be enabled
+by setting `node['fb_util_linux']['enable_fstrim']` to `true`.

--- a/cookbooks/fb_util_linux/attributes/default.rb
+++ b/cookbooks/fb_util_linux/attributes/default.rb
@@ -1,0 +1,22 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['fb_util_linux'] = {
+  'enable_fstrim' => false,
+  'manage_packages' => true,
+}

--- a/cookbooks/fb_util_linux/metadata.rb
+++ b/cookbooks/fb_util_linux/metadata.rb
@@ -1,0 +1,13 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+name 'fb_util_linux'
+maintainer 'Facebook'
+maintainer_email 'noreply@facebook.com'
+license 'Apache-2.0'
+description 'Installs/Configures fb_util_linux'
+source_url 'https://github.com/facebook/chef-cookbooks/'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+# never EVER change this number, ever.
+version '0.1.0'
+supports 'centos'
+depends 'fb_helpers'
+depends 'fb_systemd'

--- a/cookbooks/fb_util_linux/recipes/default.rb
+++ b/cookbooks/fb_util_linux/recipes/default.rb
@@ -1,0 +1,39 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Cookbook Name:: fb_util_linux
+# Recipe:: default
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+unless node.centos?
+  fail 'fb_util_linux: this cookbook is only supported on CentOS.'
+end
+
+include_recipe 'fb_util_linux::packages'
+
+node.default['fb_systemd']['preset']['fstrim.timer'] = 'disable'
+
+service 'fstrim.timer' do
+  only_if { node['fb_util_linux']['enable_fstrim'] }
+  action [:enable, :start]
+end
+
+service 'disable fstrim.timer' do
+  not_if { node['fb_util_linux']['enable_fstrim'] }
+  service_name 'fstrim.timer'
+  action [:stop, :disable]
+end

--- a/cookbooks/fb_util_linux/recipes/packages.rb
+++ b/cookbooks/fb_util_linux/recipes/packages.rb
@@ -1,0 +1,34 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Cookbook Name:: fb_util_linux
+# Recipe:: packages
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+pkgs = %w{
+  util-linux
+  libblkid
+  libfdisk
+  libmount
+  libsmartcols
+  libuuid
+}
+
+package pkgs do
+  only_if { node['fb_util_linux']['manage_packages'] }
+  action :upgrade
+end


### PR DESCRIPTION
Publishing a few more internal cookbooks:
- fb_chrony
- fb_e2fsprogs
- fb_ethtool
- fb_grubby
- fb_hostname
- fb_less
- fb_mlocate
- fb_nscd
- fb_screen
- fb_sysstat
- fb_util_linux