### PR TITLE
Give postfix the ability to log from its chroot

### DIFF
--- a/cookbooks/fb_postfix/recipes/default.rb
+++ b/cookbooks/fb_postfix/recipes/default.rb
@@ -20,6 +20,9 @@
 
 include_recipe 'fb_postfix::packages'
 
+node.default['fb_syslog']['rsyslog_additional_sockets'] <<
+  '/var/spool/postfix/dev/log'
+
 template '/etc/postfix/main.cf' do
   source 'main.cf.erb'
   owner 'root'


### PR DESCRIPTION
If the person is using fb_syslog, this does magic for them. If they
are not, it's a no-op.