### PR TITLE
fb_iptables: Fix dupe rules; output, and de-templatize

### DIFF
--- a/cookbooks/fb_iptables/recipes/default.rb
+++ b/cookbooks/fb_iptables/recipes/default.rb
@@ -77,18 +77,19 @@ template '/etc/fb_iptables.conf' do
   owner 'root'
   group 'root'
   mode '0644'
+  variables(
+    :iptables_config_dir => iptables_config_dir,
+    :iptables_rules_file => iptables_rule_file,
+    :ip6tables_rules_file => ip6tables_rule_file,
+  )
 end
 
-template '/usr/sbin/fb_iptables_reload' do
-  source 'fb_iptables_reload.erb'
+# DO NOT MAKE THIS A TEMPLATE! USE THE CONFIG FILE TEMPLATED ABOVE!!
+cookbook_file '/usr/sbin/fb_iptables_reload' do
+  source 'fb_iptables_reload.sh'
   owner 'root'
   group 'root'
   mode '0755'
-  variables(
-    :iptables_config_dir => iptables_config_dir,
-    :iptables_rules => iptables_rule_file,
-    :ip6tables_rules => ip6tables_rule_file,
-  )
 end
 
 template "#{iptables_config_dir}/iptables-config" do

--- a/cookbooks/fb_iptables/templates/default/fb_iptables.conf.erb
+++ b/cookbooks/fb_iptables/templates/default/fb_iptables.conf.erb
@@ -1,6 +1,9 @@
 <% node['fb_iptables']['dynamic_chains'].to_hash.each do |table, chains| %>
 <%=  table.tr('a-z', 'A-Z') %>_CHAINS="<%= chains.keys.join(' ') %>"
 <% end %>
+CONFIG_DIR="<%= @iptables_config_dir %>"
+RULES_FILE="<%= @iptables_rules_file %>"
+RULES6_FILE="<%= @ip6tables_rules_file %>"
 TABLES="<%= FB::Iptables::TABLES_AND_CHAINS.keys.join(' ') %>"
 <%
   FB::Iptables::TABLES_AND_CHAINS.each do |table, chains|


### PR DESCRIPTION
**Summary**:

The primary purpose of this PR was to fix the fact that reloading meant
some dynamic chains ended up with duplicates of their rules which
quickly spun out of control as the ruleset was duplicated and duplicated
over and over. In order to do that I ended up cleaning up a bunch of
stuff that had gone awry with this code since I last touched it.

* Fix the bug in question - add a space (" ") after the name of the
  chain in the grep so that we don't end up grabbing all the rules for
  FOO-BAR when we're looking for FOO. Or in this case, DOCKER-USER would
  get caught by DOCKER and thus be duplicated.

* The `fb_iptables_reload` script wasn't supposed to be a template, it
  was erroneously made into a template in https://github.com/facebook/chef-cookbooks/commit/80a8a3a5e2fbe8f603230c2aabc1abba06d73c57#diff-80bee50f4cf6d0af9c03f58ea0f9cd44
  and this undoes that. The script **has a templatized config file**!!
  @davide125 should great shame for approving that PR. =P
* Fix the bug where we don't clear the chain before we load it causing
  duplicate rules
* Make the output actually make sense
* Fix the bug where if one dynamic chain on a table wasn't populated, we
  skipped restoring any of them

**Test Plan**:

The output looks like:
```
root@host:/etc/default# /usr/sbin/fb_iptables_reload 4 reload
Reloading mangle...
  - Stashing dynamic chains on mangle: done.
  - Reloading mangle
  - Restoring dynamic chains on mangle: done.
Reloading filter...
  - Stashing dynamic chains on filter: DOCKER-USER  DOCKER-ISOLATION-STAGE-1  DOCKER  DOCKER-ISOLATION-STAGE-2  done.
  - Reloading filter
  - Restoring dynamic chains on filter: DOCKER-USER DOCKER-ISOLATION-STAGE-1 DOCKER DOCKER-ISOLATION-STAGE-2 done.
Reloading raw...
  - Stashing dynamic chains on raw: done.
  - Reloading raw
  - Restoring dynamic chains on raw: done.
```

* The rules are no longer duplicated

* The config file is populated properly:

```
root@host:/etc/default# cat /etc/fb_iptables.conf
FILTER_CHAINS="DOCKER-USER DOCKER-ISOLATION-STAGE-1 DOCKER DOCKER-ISOLATION-STAGE-2"
MANGLE_CHAINS=""
RAW_CHAINS=""
CONFIG_DIR="/etc/iptables"
RULES_FILE="rules.v4"
RULES6_FILE="rules.v6"
TABLES="mangle filter raw"
STATIC_MANGLE_CHAINS=""
STATIC_FILTER_CHAINS="INPUT FORWARD"
STATIC_RAW_CHAINS=""
```