### PR TITLE
Fix fb_systemd/fb_timers tests

### DIFF
--- a/cookbooks/fb_systemd/spec/default_spec.rb
+++ b/cookbooks/fb_systemd/spec/default_spec.rb
@@ -26,6 +26,13 @@ recipe 'fb_systemd::default', :supported => [:centos7] do |tc|
     allow(File).to receive(:directory?).and_call_original
     allow(File).to receive(:directory?).with('/run/systemd/system').
       and_return(true)
+    ml = double('systemctl')
+    allow(ml).to receive_messages(
+      :run_command => ml,
+      :stdout => "multi-user.target\n",
+    )
+    allow(Mixlib::ShellOut).to receive(:new).with('systemctl get-default').
+      and_return(ml)
   end
 
   it 'should render empty config' do

--- a/cookbooks/fb_timers/spec/default_spec.rb
+++ b/cookbooks/fb_timers/spec/default_spec.rb
@@ -37,6 +37,13 @@ recipe 'fb_timers::default', :unsupported => [:mac_os_x] do |tc|
       allow(File).to receive(:readlink).with("#{s_path}#{unit}").
         and_return("#{t_path}#{unit}")
     end
+    ml = double('systemctl')
+    allow(ml).to receive_messages(
+      :run_command => ml,
+      :stdout => "multi-user.target\n",
+    )
+    allow(Mixlib::ShellOut).to receive(:new).with('systemctl get-default').
+      and_return(ml)
   end
 
   context 'not managed by systemd' do


### PR DESCRIPTION
fb_systemd calls out to `systemctl`, but in containers that's not
always available. Therefore these unittests can fail in containers
that are based on things like Ubuntu Bionic which are systemd-y
distros, but yet don't have systemctl. Either way, these calls should
be mocked, and now they are.