### PR TITLE
Add /sbin/udevadm > /bin/udevadm symlink before using sbin path

### DIFF
--- a/cookbooks/fb_systemd/recipes/udevd.rb
+++ b/cookbooks/fb_systemd/recipes/udevd.rb
@@ -18,6 +18,12 @@
 # limitations under the License.
 #
 
+link '/sbin/udevadm' do
+  to '/bin/udevadm'
+  owner 'root'
+  group 'root'
+end
+
 execute 'trigger udev' do
   command '/sbin/udevadm trigger'
   action :nothing

--- a/cookbooks/fb_systemd/recipes/udevd.rb
+++ b/cookbooks/fb_systemd/recipes/udevd.rb
@@ -18,19 +18,26 @@
 # limitations under the License.
 #
 
+udevadm = value_for_platform(
+  'centos' => {
+    '< 6.0' => '/sbin/udevadm'
+  },
+  default => '/bin/udevadm',
+)
+
 execute 'trigger udev' do
-  command '/sbin/udevadm trigger'
+  command "#{udevadm} trigger"
   action :nothing
 end
 
 execute 'reload udev' do
-  command '/sbin/udevadm control --reload'
+  command "#{udevadm} control --reload"
   action :nothing
   notifies :run, 'execute[trigger udev]', :immediately
 end
 
 execute 'update hwdb' do
-  command '/sbin/udevadm hwdb --update'
+  command "#{udevadm} hwdb --update"
   action :nothing
 end
 

--- a/cookbooks/fb_systemd/recipes/udevd.rb
+++ b/cookbooks/fb_systemd/recipes/udevd.rb
@@ -20,9 +20,9 @@
 
 udevadm = value_for_platform(
   'centos' => {
-    '< 6.0' => '/sbin/udevadm'
+    '< 6.0' => '/sbin/udevadm',
   },
-  default => '/bin/udevadm',
+  'default' => '/bin/udevadm',
 )
 
 execute 'trigger udev' do

--- a/cookbooks/fb_systemd/recipes/udevd.rb
+++ b/cookbooks/fb_systemd/recipes/udevd.rb
@@ -18,12 +18,6 @@
 # limitations under the License.
 #
 
-link '/sbin/udevadm' do
-  to '/bin/udevadm'
-  owner 'root'
-  group 'root'
-end
-
 execute 'trigger udev' do
   command '/sbin/udevadm trigger'
   action :nothing


### PR DESCRIPTION
This pull request, if merged, will change `fb_systemd::udevd` ever-so-slightly by adding a symlink from `/sbin/udevadm` to `/bin/udevadm` at the beginning of the recipe.

The symlink creation is needed to mitigate an issue (#123) that is displayed when this recipe is run on Ubuntu 20 whereby the recipe fails due to Canonical's removal of the `/sbin/udevadm` symlink. By re-adding the symlink back to the system at the beginning of this recipe, it should ensure that the subsequent `trigger udev`, `reload udev`, and `update hwdb` `execute` resources proceed without path existence errors.

I considered a couple different alternative approaches to this fix but ultimately thought this was the most sane means of fixing this. Please feel free to dissent if you feel this approach is unsafe or not the best way to go about this.