### PR TITLE
Fix chef-cookbooks builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.rej
 Gemfile.lock
 .kitchen
+.bundle
+vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - shellcheck ./scripts/*
   - ./scripts/run_chefspec
   - ./scripts/run_rubocop .rubocop.yml
-  - ./scripts/run_foodcritic
+  - travis_wait 30 ./scripts/run_foodcritic
   - bundle exec kitchen verify $INSTANCE
 
 # Disabling deploy until we sort out Supermarket issues t39456893

--- a/README.kitchen_debug.md
+++ b/README.kitchen_debug.md
@@ -1,0 +1,8 @@
+# Debugging kitchen runs
+
+You can setup kitchen using the same commands as in `.travis.yml`, but once
+Chef runs you won't have access to connect, so modify
+`fb_sudo/attributes/default.rb` and uncomment the kitchen block.
+
+Then you can do `bundle exec kitchen login <INSTANCE>` after a failed
+run, and sudo will be passwordless so you can debug.

--- a/cookbooks/fb_apache/attributes/default.rb
+++ b/cookbooks/fb_apache/attributes/default.rb
@@ -54,7 +54,16 @@ if node['platform_family'] == 'rhel'
   modules += [
     'log_config',
     'logio',
+    'ssl',
   ]
+
+  unless node.centos6?
+    modules += [
+      'socache_shmcb',
+      'systemd',
+      'unixd',
+    ]
+  end
 
   {
     'options' => [],
@@ -141,14 +150,17 @@ default['fb_apache'] = {
     'reqtimeout' => 'mod_reqtimeout.so',
     'rewrite' => 'mod_rewrite.so',
     'setenvif' => 'mod_setenvif.so',
+    'socache_shmcb' => 'mod_socache_shmcb.so',
     'speling' => 'mod_speling.so',
     'ssl' => 'mod_ssl.so',
     'status' => 'mod_status.so',
     'substitute' => 'mod_substitute.so',
     'suexec' => 'mod_suexec.so',
+    'systemd' => 'mod_systemd.so',
     'unique_id' => 'mod_unique_id.so',
     'userdir' => 'mod_userdir.so',
     'usertrack' => 'mod_usertrack.so',
+    'unixd' => 'mod_unixd.so',
     'version' => 'mod_version.so',
     'vhost_alias' => 'mod_vhost_alias.so',
   },

--- a/cookbooks/fb_apache/recipes/default.rb
+++ b/cookbooks/fb_apache/recipes/default.rb
@@ -120,6 +120,27 @@ end
   end
 end
 
+if node.debian? || node.ubuntu?
+  # CentOS makes this symlink to the right module dir, and we make assumptions
+  # it exists, so be sure to do the same on debian
+  link '/etc/apache2/modules' do
+    to '/usr/lib/apache2/modules'
+  end
+
+  # For reasons I don't understand on Ubuntu, Apache looks for mime.types in
+  # /etc/apache2/mime.types even though it's not configured to. So make a
+  # symlink
+  link '/etc/apache2/mime.types' do
+    to '/etc/mime.types'
+  end
+end
+
+# The package comes pre-installed with module configs, but we dropp off our own
+# in fb_modules.conf. Also, we don't want non-Chef controlled module configs.
+fb_apache_cleanup_modules 'doit' do
+  mod_dir moddir
+end
+
 template "#{moddir}/fb_modules.conf" do
   not_if { node.centos6? }
   owner 'root'

--- a/cookbooks/fb_apache/resources/cleanup_modules.rb
+++ b/cookbooks/fb_apache/resources/cleanup_modules.rb
@@ -1,0 +1,20 @@
+property :mod_dir, String
+
+action :manage do
+  allowed = [
+    "#{new_resource.mod_dir}/00-mpm.conf",
+    "#{new_resource.mod_dir}/fb_modules.conf",
+  ]
+  Dir.glob("#{new_resource.mod_dir}/*").each do |f|
+    next if allowed.include?(f)
+    if ::File.symlink?(f)
+      link f do
+        action :delete
+      end
+    else
+      file f do
+        action :delete
+      end
+    end
+  end
+end

--- a/cookbooks/fb_stunnel/recipes/default.rb
+++ b/cookbooks/fb_stunnel/recipes/default.rb
@@ -33,7 +33,8 @@ package packagename do
   action :upgrade
 end
 
-if node.centos?
+# Debian/Ubuntu has a unit file
+if node.centos? && node.systemd?
   cookbook_file '/etc/systemd/system/stunnel.service' do
     source 'stunnel.service'
     owner 'root'
@@ -72,7 +73,9 @@ fb_stunnel_create_certs 'do it' do
 end
 
 service 'stunnel' do
-  only_if { node['fb_stunnel']['enable'] }
+  only_if do
+    node['fb_stunnel']['enable'] && !node['fb_stunnel']['config'].empty?
+  end
   service_name packagename
   action [:enable, :start]
 end

--- a/cookbooks/fb_sudo/attributes/default.rb
+++ b/cookbooks/fb_sudo/attributes/default.rb
@@ -41,6 +41,10 @@ default['fb_sudo'] = {
       '%sudo' => {
         'all' => 'ALL=(ALL) ALL',
       },
+      # uncomment the block below when debugging kitchen tests
+      # 'kitchen' => {
+      #   'all' => 'ALL=(ALL) NOPASSWD: ALL',
+      # },
     },
     'mac_os_x' => {
       'root' => {

--- a/cookbooks/fb_syslog/recipes/default.rb
+++ b/cookbooks/fb_syslog/recipes/default.rb
@@ -78,5 +78,6 @@ service service_name do
   action :start
   subscribes :restart, 'package[rsyslog]'
   # within vagrant, sometimes rsyslog fails to restart the first time
-  retries 1
+  retries 5
+  retry_delay 5
 end

--- a/cookbooks/fb_syslog/recipes/packages.rb
+++ b/cookbooks/fb_syslog/recipes/packages.rb
@@ -23,7 +23,8 @@ package 'rsyslog' do
   action :upgrade
 end
 
-if node.systemd? && node.centos?
+# TODO(davide125): Document this
+if node.systemd?
   fb_systemd_override 'override' do
     only_if { node['fb_syslog']['_enable_syslog_socket_override'] }
     unit_name 'rsyslog.service'


### PR DESCRIPTION
There's a handful of small issues. I want to fix them in a single
PR, otherwise you end up chasing down fixes that uncover other build
problems, so I'd like to see the build go green before wasting anyone's
time to import.

- [X] foodcritic timeout
    - Tell travis to wait up to 30 minutes
- [X] ubuntu18 - stunnel failing to start
    - Don't start the service with an empty config, stunnel won't take it
- [X] if `node['fb_base_settings']['_oscore_timers_rollout']`
    - guard this better.
- [X] Apache modules errors on Ubuntu
    - Remove configs we don't want, also create the symlink we expect
- [X] Apache mime errors
    - Create symlink
- [X] Apache start errors on CentOS7
    - Add unixd for "User", ssl and schmb for SSL stuff
    - Enable systemd for Type=notify
- [X] Rsyslog failures.
    - Two things were necessary - enabling Davide's undocumented fix, and increasing the retry delay significantly.... fortunately this only make runs longer when syslog fails
    - The "better" fix here, long-term, is probably to touch 
      /root/firstboot_os in our tests and enable this only firstboot, 
      when the race condition actually exists
- [X] gitignore
- [X] Documentation on debugging kitchen issues

It's not easy to stack a bunch of small diffs in github the way it is
in phabricator, or I would have, but I wanted to ensure the changes
would actually make all things pass. If you want to break them up into
internal PRs and close this that's fine, I don't need the credit, as
long as the tests are passing.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
