### PR TITLE
fb_apt: cookstyle + Chef 16 prep

### DIFF
--- a/cookbooks/fb_apt/resources/keys.rb
+++ b/cookbooks/fb_apt/resources/keys.rb
@@ -16,10 +16,6 @@
 # limitations under the License.
 #
 
-def whyrun_supported?
-  true
-end
-
 action :run do
   keyserver = node['fb_apt']['keyserver']
   desired_keys = node['fb_apt']['keys'].to_hash

--- a/cookbooks/fb_apt/resources/sources_list.rb
+++ b/cookbooks/fb_apt/resources/sources_list.rb
@@ -16,10 +16,6 @@
 # limitations under the License.
 #
 
-def whyrun_supported?
-  true
-end
-
 action :run do
   mirror = node['fb_apt']['mirror']
   security_mirror = node['fb_apt']['security_mirror']


### PR DESCRIPTION
This is fully backwards-compatabile with Chef 13 (at least according to
the docs).

`whyrun_supported?` has been default since 13.

And `log` stops doing notifications in 16, but `notify_group` doesn't
exist until 15.8, so I just gated it on 16+.