### PR TITLE
fb_fstab: cookstyle + Chef 16

### DIFF
--- a/cookbooks/fb_fstab/resources/default.rb
+++ b/cookbooks/fb_fstab/resources/default.rb
@@ -20,10 +20,6 @@ require 'fileutils'
 
 default_action :doeverything
 
-def whyrun_supported?
-  true
-end
-
 action_class do
   def reload_filesystems
     # this should not trigger the parent resource as an 'update' because


### PR DESCRIPTION
Drop `whyrun_supported?` - defaults to true since Chef 13