### PR TITLE
fb_grub: cookstyle + chef 16

### DIFF
--- a/cookbooks/fb_grub/README.md
+++ b/cookbooks/fb_grub/README.md
@@ -53,7 +53,7 @@ an element to the `node['fb_grub']['kernel_cmdline_args']` array.
 Simply append the full text of the kernel command line arg as an element
 to that array, e.g.:
 
-```
+```ruby
 node.default['fb_grub']['kernel_cmdline_args'] << 'crashkernel=128M'
 ```
 
@@ -64,7 +64,7 @@ instead of hard coding the device.
 
 If the device absolutely needs to be hardcoded, it can be overriden, as in:
 
-```
+```ruby
 node.default['fb_grub']['boot_disk'] = 'hd1'
 ```
 

--- a/cookbooks/fb_grub/resources/packages.rb
+++ b/cookbooks/fb_grub/resources/packages.rb
@@ -16,10 +16,6 @@
 # limitations under the License.
 #
 
-def whyrun_supported?
-  true
-end
-
 action :install do
   packages = []
   case node['fb_grub']['version']

--- a/cookbooks/fb_grub/templates/default/grub2.cfg.erb
+++ b/cookbooks/fb_grub/templates/default/grub2.cfg.erb
@@ -91,7 +91,7 @@ function load_video {
 }
 
 # efi will use different location for entries and env file
-# force it to use /boot/ device 
+# force it to use /boot/ device
 <%= root_line %>
 
 # load bls configs


### PR DESCRIPTION
* whyrun_supported? is true by default since Chef 16
* mdl + cookstyle lint as well