### PR TITLE
fb_syslog: a variety of platform fixes

### DIFF
--- a/cookbooks/fb_syslog/attributes/default.rb
+++ b/cookbooks/fb_syslog/attributes/default.rb
@@ -30,6 +30,11 @@ else
   }
 end
 
+syslog_file = value_for_platform_family(
+  ['rhel', 'fedora'] => '/var/log/messages',
+  'debian' => '/var/log/syslog',
+)
+
 # Add in some reasonable defaults for all syslog.confs
 default['fb_syslog'] = {
   'syslog-entries' => {
@@ -38,8 +43,13 @@ default['fb_syslog'] = {
       'comment' => 'Log anything info level or higher. A lot ' +
                    'of things go into their own file.',
       'selector' => '*.info;mail,authpriv,cron,' +
-                    'local2,local3,local5,local6.none',
-      'action' => '-/var/log/messages',
+        'local0,local1,local2,local3,local5,local6,local7.none',
+      'action' => "-#{syslog_file}",
+    },
+    'authlog' => {
+      'comment' => 'Log all auth stuff',
+      'selector' => 'auth,authpriv.*',
+      'action' => '/var/log/auth.log',
     },
     'mail' => {
       'comment' => 'Log all the mail messages in one place.',
@@ -54,7 +64,7 @@ default['fb_syslog'] = {
     'emergency' => {
       'comment' => 'Everybody gets emergency messages',
       'selector' => '*.emerg',
-      'action' => '*',
+      'action' => ':omusrmsg:*',
     },
     'news' => {
       'comment' => 'Save news errors of level crit and higher ' +
@@ -75,7 +85,14 @@ default['fb_syslog'] = {
     'tcp' => [],
     'udp' => [],
   },
-  'rsyslog_early_lines' => [],
+  'rsyslog_early_lines' => [
+    # Set the default permissions for all log files.
+    '$FileOwner root',
+    '$FileGroup root',
+    '$FileCreateMode 0644',
+    '$DirCreateMode 0755',
+    '$Umask 0002',
+  ],
   'rsyslog_late_lines' => [],
   'rsyslog_additional_sockets' => [],
   'rsyslog_facilities_sent_to_remote' => [],

--- a/cookbooks/fb_syslog/recipes/default.rb
+++ b/cookbooks/fb_syslog/recipes/default.rb
@@ -74,6 +74,12 @@ template config_file do
   notifies :restart, "service[#{service_name}]"
 end
 
+directory '/etc/rsyslog.d' do
+  action :delete
+  recursive true
+  notifies :restart, "service[#{service_name}]"
+end
+
 service service_name do
   action :start
   subscribes :restart, 'package[rsyslog]'

--- a/cookbooks/fb_syslog/recipes/enable.rb
+++ b/cookbooks/fb_syslog/recipes/enable.rb
@@ -19,10 +19,9 @@
 
 # this is almost identical to running 'systemctl enable rsyslog', except that it
 # has no run-time requirements and can be run while setting up a container.
-
 if node.systemd?
   link '/etc/systemd/system/syslog.service' do
-    to '/usr/lib/systemd/system/rsyslog.service'
+    to '/lib/systemd/system/rsyslog.service'
     owner 'root'
     group 'root'
     notifies :run, 'fb_systemd_reload[system instance]', :immediately

--- a/cookbooks/fb_syslog/spec/fixtures/centos6/rsyslog-kern.conf
+++ b/cookbooks/fb_syslog/spec/fixtures/centos6/rsyslog-kern.conf
@@ -24,9 +24,6 @@ $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 # not useful and an extreme performance hit
 #$ActionFileEnableSync on
 
-#
-# Set the default permissions for all log files.
-#
 $FileOwner root
 $FileGroup root
 $FileCreateMode 0644

--- a/cookbooks/fb_syslog/spec/fixtures/centos6/rsyslog.conf
+++ b/cookbooks/fb_syslog/spec/fixtures/centos6/rsyslog.conf
@@ -24,9 +24,6 @@ $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 # not useful and an extreme performance hit
 #$ActionFileEnableSync on
 
-#
-# Set the default permissions for all log files.
-#
 $FileOwner root
 $FileGroup root
 $FileCreateMode 0644

--- a/cookbooks/fb_syslog/spec/fixtures/centos6/rsyslog.conf_empty
+++ b/cookbooks/fb_syslog/spec/fixtures/centos6/rsyslog.conf_empty
@@ -24,9 +24,6 @@ $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 # not useful and an extreme performance hit
 #$ActionFileEnableSync on
 
-#
-# Set the default permissions for all log files.
-#
 $FileOwner root
 $FileGroup root
 $FileCreateMode 0644

--- a/cookbooks/fb_syslog/spec/fixtures/centos7/rsyslog-kern.conf
+++ b/cookbooks/fb_syslog/spec/fixtures/centos7/rsyslog-kern.conf
@@ -25,9 +25,6 @@ $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 # not useful and an extreme performance hit
 #$ActionFileEnableSync on
 
-#
-# Set the default permissions for all log files.
-#
 $FileOwner root
 $FileGroup root
 $FileCreateMode 0644

--- a/cookbooks/fb_syslog/spec/fixtures/centos7/rsyslog.conf
+++ b/cookbooks/fb_syslog/spec/fixtures/centos7/rsyslog.conf
@@ -25,9 +25,6 @@ $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 # not useful and an extreme performance hit
 #$ActionFileEnableSync on
 
-#
-# Set the default permissions for all log files.
-#
 $FileOwner root
 $FileGroup root
 $FileCreateMode 0644

--- a/cookbooks/fb_syslog/spec/fixtures/centos7/rsyslog.conf_empty
+++ b/cookbooks/fb_syslog/spec/fixtures/centos7/rsyslog.conf_empty
@@ -25,9 +25,6 @@ $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 # not useful and an extreme performance hit
 #$ActionFileEnableSync on
 
-#
-# Set the default permissions for all log files.
-#
 $FileOwner root
 $FileGroup root
 $FileCreateMode 0644

--- a/cookbooks/fb_syslog/templates/default/rsyslog.conf.erb
+++ b/cookbooks/fb_syslog/templates/default/rsyslog.conf.erb
@@ -71,17 +71,7 @@ $AddUnixListenSocket <%= sock %>
 # not useful and an extreme performance hit
 #$ActionFileEnableSync on
 
-#
-# Set the default permissions for all log files.
-#
-$FileOwner root
-$FileGroup root
-$FileCreateMode 0644
-$DirCreateMode 0755
-$Umask 0002
-
 <% unless node['fb_syslog']['rsyslog_early_lines'].empty? %>
-# rsyslog magic that should (be able to) win over standard syslog stuff
 <%   node['fb_syslog']['rsyslog_early_lines'].each do |line| %>
 <%=    line %>
 <%   end %>


### PR DESCRIPTION
* Make the default log file work for debian-like systmes
* Add in authlog as a default, it's in a default install anywhere I look
* Don't force default file permissions on everyone, use the API rather than hard-codi
ng it in the template
* Nuke rsyslog.d so people can't add configs outside of chef
* Fix some unittest