### PR TITLE
fb_tmpclean: lint fixes

### DIFF
--- a/cookbooks/fb_tmpclean/recipes/default.rb
+++ b/cookbooks/fb_tmpclean/recipes/default.rb
@@ -38,7 +38,12 @@ template config do
   source config_src
   mode '0755'
   owner node.root_user
+  # https://github.com/chef/cookstyle/issues/657
+  # rubocop:disable Lint/UnneededCopDisableDirective
+  # rubocop:disable ChefDeprecations/NodeMethodsInsteadofAttributes
   group node.root_group
+  # rubocop:enable ChefDeprecations/NodeMethodsInsteadofAttributes
+  # rubocop:enable Lint/UnneededCopDisableDirective
 end
 
 if node.macos?


### PR DESCRIPTION
keep cookstyle in line