### PR TITLE
Add support for reserved ranges to fb_users.

### DIFF
--- a/cookbooks/fb_users/README.md
+++ b/cookbooks/fb_users/README.md
@@ -133,6 +133,27 @@ automatically cleaned up.
 
 Also see `initialize_group` helper below.
 
+If you want to protect certain UID / GID ranges from being used across your
+managed system, you can add them to `RESERVED_UID_RANGES` and `RESERVED_GID_RANGES`.
+This can be useful if 3rd party software creates those users/groups.
+The key in the `Hash` will be a printable identifier, the value will be an object
+that responds to `.include?()`, so usually `Range` or `Array`.
+
+```
+module FB
+  class Users
+    RESERVED_UID_RANGES = {
+      'systemd dynamic users' => 61184..65519,
+      'project foo service users' => [52231, 52233],
+    }
+    RESERVED_GID_RANGES = {
+      'project x service groups' => 30100..30200
+      'acme corp service groups' => [30100,30442]
+    }
+  end
+end
+```
+
 ### Passwords in data_bags
 
 `fb_users` will also look for user passwords in a data_bag called

--- a/cookbooks/fb_users/libraries/default.rb
+++ b/cookbooks/fb_users/libraries/default.rb
@@ -32,6 +32,14 @@ module FB
           fail "fb_users[user]: User #{user} in UID map has a UID conflict"
         end
 
+        if defined?(RESERVED_UID_RANGES)
+          RESERVED_UID_RANGES.each do |identifier, range|
+            if range.include?(info['uid'])
+              fail "fb_users[user]: User #{user} in UID map is in the " +
+                "reserved range for '#{identifier}'"
+            end
+          end
+        end
         uids[info['uid']] = nil
       end
 
@@ -41,6 +49,14 @@ module FB
           fail "fb_users[group]: group #{group} in GID map has a GID conflict"
         end
 
+        if defined?(RESERVED_GID_RANGES)
+          RESERVED_GID_RANGES.each do |identifier, range|
+            if range.include?(info['gid'])
+              fail "fb_users[group]: Group #{group} in GID map is in the " +
+                "reserved range for '#{identifier}'"
+            end
+          end
+        end
         uids[info['gid']] = nil
       end
 

--- a/cookbooks/fb_users/spec/default_spec.rb
+++ b/cookbooks/fb_users/spec/default_spec.rb
@@ -1,0 +1,109 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require './spec/spec_helper'
+require_relative '../libraries/default'
+
+recipe 'fb_users::default' do |_tc|
+  describe FB::Users do
+    let(:node) { Chef::Node.new }
+    context 'Validation' do
+      before(:each) do
+        node.default['fb_users'] = {
+          'user_defaults' => {},
+          'users' => {
+            'testuser' => {
+              'shell' => '/bin/zsh',
+              'gid' => 'testgroup',
+              'action' => :add,
+            },
+          },
+          'groups' => {
+            'testgroup' => {
+              'members' => ['testuser'],
+              'action' => :add,
+            },
+          },
+        }
+      end
+
+      it 'should not fail if we did not specify protected ranges' do
+        stub_const('FB::Users::UID_MAP', { 'testuser' => { 'uid' => 42 } })
+        stub_const('FB::Users::GID_MAP', { 'testgroup' => { 'gid' => 4242 } })
+        expect { FB::Users._validate(node) }.not_to raise_error
+      end
+
+      it 'should not fail if we did not specify a protected uid range' do
+        stub_const('FB::Users::UID_MAP', { 'testuser' => { 'uid' => 42 } })
+        stub_const('FB::Users::GID_MAP', { 'testgroup' => { 'gid' => 4242 } })
+        stub_const('FB::Users::RESERVED_GID_RANGES', { 'my gid' => [777] })
+        expect { FB::Users._validate(node) }.not_to raise_error
+      end
+
+      it 'should not fail if we did not specify a protected gid range' do
+        stub_const('FB::Users::UID_MAP', { 'testuser' => { 'uid' => 42 } })
+        stub_const('FB::Users::GID_MAP', { 'testgroup' => { 'gid' => 4242 } })
+        stub_const('FB::Users::RESERVED_UID_RANGES', { 'my uid' => [77] })
+        expect { FB::Users._validate(node) }.not_to raise_error
+      end
+
+      it 'should not fail if nothing collides' do
+        stub_const('FB::Users::UID_MAP', { 'testuser' => { 'uid' => 42 } })
+        stub_const('FB::Users::GID_MAP', { 'testgroup' => { 'gid' => 4242 } })
+        stub_const('FB::Users::RESERVED_UID_RANGES', { 'my uid' => [99..222] })
+        stub_const('FB::Users::RESERVED_GID_RANGES', { 'my gid' => [45, 77] })
+        expect { FB::Users._validate(node) }.not_to raise_error
+      end
+
+      it 'should fail if a protected uid array collides with a user' do
+        stub_const('FB::Users::UID_MAP', { 'testuser' => { 'uid' => 42 } })
+        stub_const('FB::Users::GID_MAP', { 'testgroup' => { 'gid' => 4242 } })
+        stub_const('FB::Users::RESERVED_UID_RANGES', { 'my uid' => [42] })
+        expect { FB::Users._validate(node) }.to raise_error(
+          RuntimeError, /User testuser in UID map is in the reserved range/
+        )
+      end
+
+      it 'should fail if a protected uid range collides with a user' do
+        stub_const('FB::Users::UID_MAP', { 'testuser' => { 'uid' => 42 } })
+        stub_const('FB::Users::GID_MAP', { 'testgroup' => { 'gid' => 4242 } })
+        stub_const('FB::Users::RESERVED_UID_RANGES', { 'my uid' => 40..44 })
+        expect { FB::Users._validate(node) }.to raise_error(
+          RuntimeError, /User testuser in UID map is in the reserved range/
+        )
+      end
+
+      it 'should fail if a protected gid array collides with a group' do
+        stub_const('FB::Users::UID_MAP', { 'testuser' => { 'uid' => 42 } })
+        stub_const('FB::Users::GID_MAP', { 'testgroup' => { 'gid' => 4242 } })
+        stub_const('FB::Users::RESERVED_GID_RANGES', { 'my gid' => [23, 4242] })
+        expect { FB::Users._validate(node) }.to raise_error(
+          RuntimeError, /Group testgroup in GID map is in the reserved range/
+        )
+      end
+
+      it 'should fail if a protected gid range collides with a group' do
+        stub_const('FB::Users::UID_MAP', { 'testuser' => { 'uid' => 42 } })
+        stub_const('FB::Users::GID_MAP', { 'testgroup' => { 'gid' => 4242 } })
+        stub_const('FB::Users::RESERVED_GID_RANGES', { 'my gid' => 4240..4244 })
+        expect { FB::Users._validate(node) }.to raise_error(
+          RuntimeError, /Group testgroup in GID map is in the reserved range/
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Summary:
There are cases where you don't manage a certain UID/GID, but you would like to make sure that nobody else accidentally tries to put their own user/group in that range either.

This code adds the ability to specify protected ranges which would fail validation if someone where to attempt putting a new UID/GID inside those ranges.

Differential Revision: D23817151

