### PR TITLE
Add alternate acceptable platform value for def macos?

### DIFF
--- a/cookbooks/fb_helpers/libraries/node_methods.rb
+++ b/cookbooks/fb_helpers/libraries/node_methods.rb
@@ -120,7 +120,7 @@ class Chef
     end
 
     def macos?
-      self['platform'] == 'mac_os_x'
+      self['platform'] == 'mac_os_x' || self['platform'] == 'macos'
     end
 
     alias macosx? macos?

--- a/cookbooks/fb_helpers/libraries/node_methods.rb
+++ b/cookbooks/fb_helpers/libraries/node_methods.rb
@@ -120,7 +120,7 @@ class Chef
     end
 
     def macos?
-      self['platform'] == 'mac_os_x' || self['platform'] == 'macos'
+      %w{mac_os_x macos}.include?(self['platform'])
     end
 
     alias macosx? macos?


### PR DESCRIPTION
On some versions of Chef and macOS `node['platform'] returns `macos` instead of `mac_os_x`, this PR will allow either to be acceptable respones for `node.macos?` to return true.