### PR TITLE
Add modern distros to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,12 @@ jobs:
         os:
           - centos-6
           - centos-7
+          - centos-8
           - ubuntu-1604
           - ubuntu-1804
+          - ubuntu-2004
           - debian-9
+          - debian-10
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Add ubuntu 20.04, Centos 8, and Debian 10