### PR TITLE
use manage_home value if set

### DIFF
--- a/cookbooks/fb_users/resources/default.rb
+++ b/cookbooks/fb_users/resources/default.rb
@@ -80,8 +80,8 @@ action :manage do
     homedir = info['home'] || "/home/#{username}"
     # If `manage_homedir` isn't set, we'll use a user-specified default.
     # If *that* isn't set, then
-    manage_homedir = nil
-    unless info['manage_home']
+    manage_homedir = info['manage_home']
+    if manage_homedir.nil?
       if node['fb_users']['user_defaults']['manage_home']
         manage_homedir = node['fb_users']['user_defaults']['manage_home']
       else


### PR DESCRIPTION
Summary:

I believe there is a bug in `fb_users` -- the value for `manage_home` is currently not passed to the `user` resource. This prevents a home directory from being created if `manage_home` is `true`.

Differential Revision: D26134628

