### PR TITLE
Add windows support to fb_ntp

### DIFF
--- a/cookbooks/fb_ntp/resources/windows_config.rb
+++ b/cookbooks/fb_ntp/resources/windows_config.rb
@@ -1,0 +1,39 @@
+action_class do
+  def get_current_config
+    config = {}
+    section = nil
+    s = powershell_exec('w32tm /query /configuration')
+    s.result.each do |line|
+      case line
+      when /^\[(.*)\]$/
+        section = $1
+        config[section] = {}
+      when /^(\w+)\s*:\s*([^\(]+) \(.*\)$/
+        config[section][$1] = $2
+      end
+    end
+    config
+  end
+
+  def set_ntp_servers
+    execute 'set NTP servers' do
+      command 'w32tm /configure /reliable:yes /syncfromflags:manual ' +
+        "/manualpeerlist:#{node['fb_ntp']['servers'].join(',')} /update"
+    end
+  end
+end
+
+action :config do
+  config = get_current_config
+  want = node['fb_ntp']['servers']
+  have = config['TimeProviders']['NtpServer'].split(',')
+  if Set.new(want) != Set.new(have)
+    Chef::Log.info(
+      'fb_ntp_windows_config: Changing NTP servers from ' +
+      "#{have.join(', ')} to #{want.join(', ')}",
+    )
+    set_ntp_servers
+  else
+    Chef::Log.debug('fb_ntp_windows_config: NTP servers are correct')
+  end
+end

--- a/cookbooks/fb_ntp/resources/windows_config.rb
+++ b/cookbooks/fb_ntp/resources/windows_config.rb
@@ -29,11 +29,11 @@ action :config do
   have = config['TimeProviders']['NtpServer'].split(',')
   if Set.new(want) != Set.new(have)
     Chef::Log.info(
-      'fb_ntp_windows_config: Changing NTP servers from ' +
+      'fb_ntp[windows_config]: Changing NTP servers from ' +
       "#{have.join(', ')} to #{want.join(', ')}",
     )
     set_ntp_servers
   else
-    Chef::Log.debug('fb_ntp_windows_config: NTP servers are correct')
+    Chef::Log.debug('fb_ntp[windows_config]: NTP servers are correct')
   end
 end


### PR DESCRIPTION
This PR adds basic windows support to fb_ntp.

The support is just for setting NTP servers and ensureing the service
is running. There are other things one can set and this could be
extended if desired, but it works well for now.

Note this uses powershell_exec which I think requires Chef 16. It could
be moved to powershell_out if necessary, though that is much, *much*
slower.

This also has a chefstyle autocorrect which does implicit rescue which
requires Chef 13, but I _think_ the last of 12 is dead at FB so that
should be fine, but someone should doublecheck.