### PR TITLE
Cleanup fb_users run_contexts

### DIFF
--- a/cookbooks/fb_users/recipes/default.rb
+++ b/cookbooks/fb_users/recipes/default.rb
@@ -19,6 +19,12 @@
 # limitations under the License.
 #
 
+if defined?(ChefSpec)
+  file 'test resource' do
+    action :nothing
+  end
+end
+
 whyrun_safe_ruby_block 'validate users and groups' do
   block do
     FB::Users._validate(node)

--- a/cookbooks/fb_users/resources/default.rb
+++ b/cookbooks/fb_users/resources/default.rb
@@ -190,6 +190,7 @@ action :manage do
           info['notifies']&.each_value do |notif|
             timing = notif['timing'] || 'delayed'
             notifies notif['action'].to_sym, notif['resource'], timing.to_sym
+            notifies notif['action'], notif['resource']
           end
         end
       end


### PR DESCRIPTION
Follow-up to #171 - once that's in and everyone's added their notifies, we
can drop all this.

Note that because of the way GH works, this actually currently includes all
of #171, but I'll rebase this once that's in. You can go to commits and choose
just the second commit to see what this PR is actually doing by itself.

Signed-off-by: Phil Dibowitz <phil@ipom.com>