### PR TITLE
fb_consul: Allow pinning of Consul version

### DIFF
--- a/cookbooks/fb_consul/README.md
+++ b/cookbooks/fb_consul/README.md
@@ -8,6 +8,8 @@ Requirements
 Attributes
 ----------
 * node['fb_consul']['enable']
+* node['fb_consul']['manage_packages']
+* node['fb_consul']['version']
 * node['fb_consul']['config']
 * node['fb_consul']['services']
 * node['fb_consul']['checks']

--- a/cookbooks/fb_consul/attributes/default.rb
+++ b/cookbooks/fb_consul/attributes/default.rb
@@ -19,6 +19,7 @@
 default['fb_consul'] = {
   'enable' => true,
   'manage_packages' => true,
+  'version' => nil,
   'config' => {
     'node_name' => node['hostname'],
     'bind_addr' => '0.0.0.0',

--- a/cookbooks/fb_consul/recipes/default.rb
+++ b/cookbooks/fb_consul/recipes/default.rb
@@ -35,9 +35,20 @@ node.default['fb_users']['users']['consul'] = {
   'shell' => '/usr/sbin/nologin',
 }
 
-package 'consul' do
+package 'upgrade consul' do
+  package_name 'consul'
   only_if { node['fb_consul']['manage_packages'] }
+  only_if { node['fb_consul']['version'].nil? }
   action :upgrade
+  notifies :restart, 'service[consul]'
+end
+
+package 'pin consul' do
+  package_name 'consul'
+  only_if { node['fb_consul']['manage_packages'] }
+  not_if { node['fb_consul']['version'].nil? }
+  action :install
+  version lazy { node['fb_consul']['version'] }
   notifies :restart, 'service[consul]'
 end
 


### PR DESCRIPTION
Summary: Add the `version` attribute to the fb_consul API to allow for
consumers to pin to a specified Consul version.

Example output from a Chef run with
`node.default['fb_consul']['version']` not set

```sh
...
Recipe: fb_consul::default
  * apt_package[upgrade consul] action upgrade (up to date)
  * apt_package[pin consul] action install (skipped due to not_if)
...
```

Example output from a Chef run with
`node.default['fb_consul']['version']` set

```sh
...
Recipe: fb_consul::default
  * apt_package[upgrade consul] action upgrade (skipped due to only_if)
  * apt_package[pin consul] action install (up to date)
...
```