### PR TITLE
Add macos12 example to readme

### DIFF
--- a/cookbooks/fb_helpers/README.md
+++ b/cookbooks/fb_helpers/README.md
@@ -146,6 +146,9 @@ your node.
 * `node.macos11?`
     Is macOS Big Sur (macOS 11)
 
+* `node.macos12?`
+    Is macOS Monterey (macOS 12)
+
 * `node.windows?`
     Is Windows
 


### PR DESCRIPTION
The `macos12` function is already in node_methods.rb, but not yet in the readme.