### PR TITLE
Favor `respond_to?` over `begin...rescue`

### DIFF
--- a/cookbooks/fb_helpers/libraries/node_methods.rb
+++ b/cookbooks/fb_helpers/libraries/node_methods.rb
@@ -892,9 +892,9 @@ class Chef
       # implicit-begin is a function of ruby2.5 and later, but we still
       # support 2.4, so.... until then
       node_path.inject(self) do |location, key|
-        begin
+        if key.respond_to?(:to_s) && location.respond_to?(:attribute?)
           location.attribute?(key.to_s) ? location[key] : default
-        rescue NoMethodError
+        else
           default
         end
       end


### PR DESCRIPTION
We currently run `fasterer` in CI against our internal Chef repository and after updating our internal copy of `fb_helpers` (to be in-sync with this upstream) this `begin...rescue` block was flagged by `fasterer`:
```
fb_helpers/libraries/node_methods.rb:897 Don't rescue NoMethodError, rather check with respond_to?.
```

Implementing this small change could improve speed performance of the function _up to_ 8x.

I am open to alternative approaches to this but this was the first one that came to mind (and this repo already contains usages of `#respond_to?` so I didn't have to worry about compatibility of newly introduced methods and legacy Ruby versions in-use at Facebook).

See: https://github.com/JuanitoFatas/fast-ruby#beginrescue-vs-respond_to-for-control-flow-code