### PR TITLE
Some lint fixes for fb_apache

### DIFF
--- a/cookbooks/fb_apache/attributes/default.rb
+++ b/cookbooks/fb_apache/attributes/default.rb
@@ -50,7 +50,8 @@ sysconfig = {
   '_extra_lines' => [],
 }
 
-if node['platform_family'] == 'rhel'
+case node['platform_family']
+when 'rhel'
   modules += [
     'log_config',
     'logio',
@@ -71,7 +72,7 @@ if node['platform_family'] == 'rhel'
   }.each do |k, v|
     sysconfig[k] = v
   end
-elsif node['platform_family'] == 'debian'
+when 'debian'
   {
     'htcacheclean_run' => 'auto',
     'htcacheclean_mode' => 'daeon',

--- a/cookbooks/fb_apache/libraries/default.rb
+++ b/cookbooks/fb_apache/libraries/default.rb
@@ -37,15 +37,16 @@ module FB
       buf << indentstr(indent)
       buf << "<#{kw}>\n"
       data.each do |key, val|
-        if val.is_a?(String)
+        case val
+        when String
           buf << indentstr(indent + 1)
           buf << "#{key} #{val}\n"
-        elsif val.is_a?(Hash)
+        when Hash
           template_hash_handler(buf, indent + 1, key, val)
         end
       end
       buf << indentstr(indent)
-      buf << "</#{kw.split(' ')[0]}>\n"
+      buf << "</#{kw.split[0]}>\n"
     end
 
     # Helper for rewrite syntax

--- a/cookbooks/fb_apache/recipes/default.rb
+++ b/cookbooks/fb_apache/recipes/default.rb
@@ -22,8 +22,14 @@ node.default['fb_apache']['module_packages']['wsgi'] =
   case node['platform_family']
   when 'rhel'
     node['platform_version'].to_f >= 8 ? 'python3-mod_wsgi' : 'mod_wsgi'
+  when 'debian'
+    'libapache2-mod-wsgi-py3'
+  else
+    'mod_wsgi'
   end
 
+# Case makes sense in every other case, so lets keep it here for consistency
+# rubocop:disable Chef/Style/UnnecessaryPlatformCaseStatement
 node.default['fb_apache']['modules_mapping']['wsgi'] =
   case node['platform_family']
   when 'rhel'
@@ -31,6 +37,7 @@ node.default['fb_apache']['modules_mapping']['wsgi'] =
   else
     'mod_wsgi.so'
   end
+# rubocop:enable Chef/Style/UnnecessaryPlatformCaseStatement
 
 apache_version =
   case node['platform_family']

--- a/cookbooks/fb_apache/resources/cleanup_modules.rb
+++ b/cookbooks/fb_apache/resources/cleanup_modules.rb
@@ -25,6 +25,7 @@ action :manage do
   ]
   Dir.glob("#{new_resource.mod_dir}/*").each do |f|
     next if allowed.include?(f)
+
     if ::File.symlink?(f)
       link f do
         action :delete

--- a/cookbooks/fb_apache/resources/verify_configs.rb
+++ b/cookbooks/fb_apache/resources/verify_configs.rb
@@ -8,7 +8,6 @@ property :confdir, String
 default_action :verify
 
 action :verify do
-
   # Verify configurations of interest using apache syntax checker `httpd -t`.
   # By default, this command run ondisc files which is too late for Chef to
   # catch anything invalid. To catch bad configs ahead of time, we copy the
@@ -86,10 +85,9 @@ action :verify do
     verify_cmd = value_for_platform_family(
       'rhel' => "httpd -t -d #{tdir}",
       'debian' => "apachectl -t -d #{tdir}",
-      )
+    )
     Chef::Log.debug("fb_apache: verify using #{verify_cmd}")
-    s = Mixlib::ShellOut.new(verify_cmd).run_command
+    s = shell_out(verify_cmd)
     s.error!
   end
-
 end


### PR DESCRIPTION
This handles newer rubocop/cookstyle fixes. Should still all
be compatible with Chef 12, though I believe you're all the way to 13.