### PR TITLE
Modernize/lint fb_sysfs

### DIFF
--- a/cookbooks/fb_sysfs/README.md
+++ b/cookbooks/fb_sysfs/README.md
@@ -51,7 +51,7 @@ end
 `path` is the name property, but you may specify it directly should you need to
 evaluate it lazily:
 
-```
+```ruby
 fb_sysfs "Set some stuff" do
   path lazy { node['fb_foo']['bar'] }
   value 'food'

--- a/cookbooks/fb_sysfs/resources/default.rb
+++ b/cookbooks/fb_sysfs/resources/default.rb
@@ -19,11 +19,10 @@
 
 default_action :set
 
-property :path, :name_property => true
-property :value, :is => [String, Integer, :EINVAL], :required => true
-property :type, :is => Symbol, :required => true, :default => :string
-property :ignore_einval, :is => [TrueClass, FalseClass], :required => true,
-                         :default => false
+property :path, String, :name_property => true
+property :value, [String, Integer, :EINVAL], :required => true
+property :type, Symbol, :required => true
+property :ignore_einval, [true, false], :default => false
 
 action_class do
   include FB::Sysfs::Provider


### PR DESCRIPTION
All of these are Chef 13-safe as far as I can tell:

* Can't have default and required together. You wante default
* Type is the first argument, not something under `:is`

Here's the output with links and version info:

```
cookbooks/fb_sysfs/resources/default.rb:22:1: R: Chef/Correctness/PropertyWithoutType: Resource properties or attributes should always define a type to help users understand the correct allowed values. (https://docs.chef.io/workstation/cookstyle/chef_correctness_propertywithouttype)
property :path, :name_property => true
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cookbooks/fb_sysfs/resources/default.rb:23:1: R: Chef/Correctness/PropertyWithoutType: Resource properties or attributes should always define a type to help users understand the correct allowed values. (https://docs.chef.io/workstation/cookstyle/chef_correctness_propertywithouttype)
property :value, :is => [String, Integer, :EINVAL], :required => true
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cookbooks/fb_sysfs/resources/default.rb:24:1: R: Chef/Correctness/PropertyWithoutType: Resource properties or attributes should always define a type to help users understand the correct allowed values. (https://docs.chef.io/workstation/cookstyle/chef_correctness_propertywithouttype)
property :type, :is => Symbol, :required => true, :default => :string
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cookbooks/fb_sysfs/resources/default.rb:24:1: R: [Correctable] Chef/RedundantCode/PropertyWithRequiredAndDefault: Resource properties should not be both required and have a default value. This will fail on Chef Infra Client 13+ (https://docs.chef.io/workstation/cookstyle/chef_redundantcode_propertywithrequiredanddefault)
property :type, :is => Symbol, :required => true, :default => :string
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cookbooks/fb_sysfs/resources/default.rb:25:1: R: Chef/Correctness/PropertyWithoutType: Resource properties or attributes should always define a type to help users understand the correct allowed values. (https://docs.chef.io/workstation/cookstyle/chef_correctness_propertywithouttype)
property :ignore_einval, :is => [TrueClass, FalseClass], :required => true, ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cookbooks/fb_sysfs/resources/default.rb:25:1: R: [Correctable] Chef/RedundantCode/PropertyWithRequiredAndDefault: Resource properties should not be both required and have a default value. This will fail on Chef Infra Client 13+ (https://docs.chef.io/workstation/cookstyle/chef_redundantcode_propertywithrequiredanddefault)
property :ignore_einval, :is => [TrueClass, FalseClass], :required => true, ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cookbooks/fb_sysfs/resources/default.rb:28:1: R: [Correctable] Chef/Modernize/WhyRunSupportedTrue: whyrun_supported? no longer needs to be set to true as it is the default in Chef Infra Client 13+ (https://docs.chef.io/workstation/cookstyle/chef_modernize_whyrunsupportedtrue)
def whyrun_supported? ...
^^^^^^^^^^^^^^^^^^^^^
```

Plus a small markdownlint fix.