### PR TITLE
Move rubocop to target Ruby 2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.4, 2.5, 2.6]
+        ruby: [2.5, 2.6, 2.7]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Exclude:
     # template files named `rb` instead of `erb` are a sin against ruby-nature.
     - '**/templates/**/*.rb'#

--- a/.rubocop_49.yml
+++ b/.rubocop_49.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Exclude:
     # template files named `rb` instead of `erb` are a sin against ruby-nature.
     - '**/templates/**/*.rb'#

--- a/.rubocop_55.yml
+++ b/.rubocop_55.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Exclude:
     # template files named `rb` instead of `erb` are a sin against ruby-nature.
     - '**/templates/**/*.rb'#

--- a/cookbooks/fb_grubby/libraries/fb_grubby_helpers.rb
+++ b/cookbooks/fb_grubby/libraries/fb_grubby_helpers.rb
@@ -25,9 +25,7 @@ module FB
     end
 
     def self.kernels
-      @kernels ||= begin
-        ::Dir.glob('/boot/vmlinuz-*-*.*.*').sort
-      end
+      @kernels ||= ::Dir.glob('/boot/vmlinuz-*-*.*.*').sort
     end
 
     def get_boot_entry(kernel_path)

--- a/cookbooks/fb_helpers/libraries/node_methods.rb
+++ b/cookbooks/fb_helpers/libraries/node_methods.rb
@@ -892,11 +892,11 @@ class Chef
       # implicit-begin is a function of ruby2.5 and later, but we still
       # support 2.4, so.... until then
       node_path.inject(self) do |location, key|
-        begin
-          location.attribute?(key.to_s) ? location[key] : default
-        rescue NoMethodError
-          default
-        end
+
+        location.attribute?(key.to_s) ? location[key] : default
+      rescue NoMethodError
+        default
+
       end
     end
 

--- a/cookbooks/fb_helpers/spec/version_spec.rb
+++ b/cookbooks/fb_helpers/spec/version_spec.rb
@@ -22,7 +22,7 @@ describe FB::Version do
     expect(FB::Version.new('1.3').to_a).to eq([1, 3])
   end
 
-  # rubocop:disable Lint/UselessComparison,Style/CaseEquality,Metrics/LineLength
+  # rubocop:disable Lint/UselessComparison,Style/CaseEquality,Layout/LineLength
   context 'compares versions' do
     it 'less than' do
       expect(FB::Version.new('1.3') < FB::Version.new('1.21')).to eq(true)
@@ -65,7 +65,7 @@ describe FB::Version do
       expect(FB::Version.new('1.2.36') === FB::Version.new('1.4.35')).to eq(false)
     end
   end
-  # rubocop:enable Lint/UselessComparison,Style/CaseEquality,Metrics/LineLength
+  # rubocop:enable Lint/UselessComparison,Style/CaseEquality,Layout/LineLength
   context 'old behavior' do
     context 'broken' do
       it 'ignores _' do

--- a/cookbooks/fb_ntp/recipes/default.rb
+++ b/cookbooks/fb_ntp/recipes/default.rb
@@ -48,16 +48,16 @@ whyrun_safe_ruby_block 'enforce ACL hardening' do
     # implicit-begin is a function of ruby2.5 and later, but we still
     # support 2.4, so.... until then
     node['fb_ntp']['servers'].each do |host|
-      begin
-        ips = Resolv.getaddresses(host)
-        ips.each do |ip|
-          dash6 = ''
-          dash6 = '-6 ' if IPAddr.new(ip).ipv6?
-          acl_entries << "restrict #{dash6}#{ip} ##{host}"
-        end
-      rescue Resolv::ResolvError
-        Chef::Log.warn("fb_ntp: failed to resolve #{host}, skipping")
+
+      ips = Resolv.getaddresses(host)
+      ips.each do |ip|
+        dash6 = ''
+        dash6 = '-6 ' if IPAddr.new(ip).ipv6?
+        acl_entries << "restrict #{dash6}#{ip} ##{host}"
       end
+    rescue Resolv::ResolvError
+      Chef::Log.warn("fb_ntp: failed to resolve #{host}, skipping")
+
     end
 
     node.default['fb_ntp']['acl_entries'] = acl_entries +

--- a/spec/fbspec_platforms.rb
+++ b/spec/fbspec_platforms.rb
@@ -19,32 +19,32 @@
 
 PLATFORMS = if Fauxhai::VERSION.start_with?('6')
               {
-                centos7: [
+                :centos7 => [
                   {
                     'platform' => 'centos',
-                    'version' => '7.3.1611'
-                  }
+                    'version' => '7.3.1611',
+                  },
                 ],
-                mac_os_x: [
+                :mac_os_x => [
                   {
                     'platform' => 'mac_os_x',
-                    'version' => '10.12'
-                  }
-                ]
+                    'version' => '10.12',
+                  },
+                ],
               }.freeze
             else
               {
-                centos8: [
+                :centos8 => [
                   {
                     'platform' => 'centos',
-                    'version' => '8'
-                  }
+                    'version' => '8',
+                  },
                 ],
-                mac_os_x: [
+                :mac_os_x => [
                   {
                     'platform' => 'mac_os_x',
-                    'version' => '10.15'
-                  }
-                ]
+                    'version' => '10.15',
+                  },
+                ],
               }.freeze
             end


### PR DESCRIPTION
Chef 13's omnibus has Ruby 2.5 in it, so we no longer need to target
2.4. This moves rubocop to target 2.5 and runs auto-lint on the
codebase.

There are only a small number of changes. This will also prevent
lint from failing as I'm sending PRs with our downstream changes.