### PR TITLE
fb_iptables: simple function to enable NAT

### DIFF
--- a/cookbooks/fb_iptables/README.md
+++ b/cookbooks/fb_iptables/README.md
@@ -121,19 +121,19 @@ translated to key-value pairs in the config file. The keys will automatically be
 upper-cased and prefixed with `IPTABLES_` or `IP6TABLES_` as necessary. For
 example:
 
-```
+```ruby
 node.default['fb_iptables']['sysconfig']['modules'] = 'nat'
 ```
 
 would translate to:
 
-```
+```bash
 IPTABLES_MODULES="nat"
 ```
 
 and:
 
-```
+```bash
 IP6TABLES_MODULES="nat"
 ```
 
@@ -143,5 +143,8 @@ if you need to trigger on rules reloading.
 
 ### Unsupported features
 The `nat` and `security` tables are not currently supported.
+
+However, you can call `FB::Iptables.enable_nat(node)` to safely initialize
+the `nat` structures for use.
 
 User defined table are not supported.


### PR DESCRIPTION
FB doesn't have NAT in their kernels and thus fb_iptables doesn't
support it. It's easy enough to add support to it from a wrapper
cookbook by amending all the right data structures, but if two
different cookbooks do it they can step on each other.

This PR provides a method that others can call to setup the NAT table
structures safely/idempotently while still keeping it disabled by
default.

Talked this over with @dvaide125 and he agreed this was a mutually
agreeable approach.