### PR TITLE
Add CODEOWNERS so reviewers are auto-populated

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Make sure PRs get reviewers auto-added. Approve/merging
+# won't actually be affected as this repo uses ImportIt and ShipIt
+# to do the actual work internally and then have it pushed back to GH
+* @jaymzh @NaomiReeves @joshuamiller01 @davide125


### PR DESCRIPTION
PRs don't get reviewers added often, adding a CODEOWNERS will get
them auto populated.

Since this repo uses ImportIt and ShipIt, it won't change anything about
the approval/merging process at all.