### PR TITLE
Fix fb_logrotate craziness

### DIFF
--- a/cookbooks/fb_logrotate/README.md
+++ b/cookbooks/fb_logrotate/README.md
@@ -32,7 +32,7 @@ per logrotate configuration block.
 
 To rotate a new set of logs, add a new entry to this hash, like so:
 
-```
+```ruby
 node.default['fb_logrotate']['configs']['myapp'] = {
   'files' => ['/var/log/myapp.log'],
   'overrides' => {
@@ -145,7 +145,7 @@ otherwise warning message will be issued.
 Let's go ahead and now take a look at a full sample structure, and
 the resulting config file it would generate:
 
-```
+```ruby
 node.default['fb_logrotate']['configs']['mcproxy'] = {
   'files' => [
     "/var/log/mcproxy-tao.log",
@@ -170,7 +170,7 @@ node.default['fb_logrotate']['configs']['mcproxy'] = {
 
 From the above structure, the following config file is generated:
 
-```
+```text
 /var/log/mcproxy-tao.log /var/log/mcproxy-tao2.log /var/log/mcproxy.init.log /var/log/mcproxy.tao.log /var/log/mcproxy.tao2.log /var/log/mcproxy2.tao.log /var/log/mcproxy.log.global /var/log/mcproxy.log /var/log/mcproxy.global /var/log/mcproxy.regional.log {
   size 50M
   copytruncate
@@ -182,7 +182,7 @@ From the above structure, the following config file is generated:
 Another example that shows the newsyslog.d conf file as generated on a MAC
 machine using the following sample strucutre:
 
-```
+```ruby
 node.default['fb_logrotate']['configs']['mylogfile'] = {
   'files' => ['/var/log/mylogfile'],
   'overrides' => {
@@ -194,7 +194,7 @@ node.default['fb_logrotate']['configs']['mylogfile'] = {
 From the above structure, the a config file
 (/etc/newsyslog.d/fb_bsd_newsyslog.conf) is generated with output:
 
-```
+```text
 # logfilename                       [owner:group]        mode count size     when  flags [/pid_file] [sig_num]
 /var/log/messages                                        644  5     1024     24    J
 /var/log/mylogfile                                       644  14    1048576  *     J

--- a/cookbooks/fb_logrotate/recipes/default.rb
+++ b/cookbooks/fb_logrotate/recipes/default.rb
@@ -37,24 +37,40 @@ whyrun_safe_ruby_block 'munge logrotate configs' do
     node['fb_logrotate']['configs'].to_hash.each do |name, block|
       time = nil
       if block['overrides']
-        # if someone wants to override weekly but didn't specify
-        # how many to keep, we default to 4
-        if block['overrides']['rotation'] == 'weekly' &&
-           !block['overrides']['rotate']
-          node.default['fb_logrotate']['configs'][name][
-            'overrides']['rotate'] = '4'
+        rotation = block['overrides']['rotation']
+        size = block['overrides']['size']
+
+        if rotation && size
+          fail "fb_logrotate:[#{name}]: you can only use size or rotation " +
+            'not both'
+        end
+        
+        if rotation
+          # if someone wants to override weekly but didn't specify
+          # how many to keep, we default to 4
+          if rotation == 'weekly' && !block['overrides']['rotate']
+            node.default['fb_logrotate']['configs'][name][
+              'overrides']['rotate'] = '4'
+          end
+
+          if %w{hourly daily weekly monthly yearly}.include?(rotation)
+            time = rotation
+            node.rm(:fb_logrotate, :configs, name, :overrides, :rotation)
+          else
+            fail "fb_logrotate:[#{name}]: rotation #{rotation} invalid"
+          end
         end
 
-        if block['overrides']['size']
-          time = "size #{block['overrides']['size']}"
+        if size
+          time = "size #{size}"
           node.rm(:fb_logrotate, :configs, name, :overrides, :size)
-        elsif %w{hourly weekly monthly yearly}.include?(
-          block['overrides']['rotation'],
-        )
-          time = block['overrides']['rotation']
-          node.rm(:fb_logrotate, :configs, name, :overrides, :rotation)
         end
-        time = nil if time == 'daily'
+
+        if block['overrides']['nocompress'] &&
+           node['fb_logrotate']['globals']['nocompress']
+          # redundant, remove
+          node.rm(:fb_logrotate, :configs, name, :overrides, :nocompress)
+        end
       end
       if time
         node.default['fb_logrotate']['configs'][name]['time'] = time

--- a/cookbooks/fb_logrotate/templates/default/fb_logrotate.conf.erb
+++ b/cookbooks/fb_logrotate/templates/default/fb_logrotate.conf.erb
@@ -25,42 +25,11 @@ size  <%= node['fb_logrotate']['globals']['size'] %>
 compressext <%= node['fb_logrotate']['globals']['compressext'] %>
 <% end -%>
 
-<% node['fb_logrotate']['configs'].to_hash.each do |name, block|
-  time = nil
-  if block['overrides']
-    rotation = block['overrides']['rotation']
-    size = block['overrides']['size']
-    if rotation
-      if size
-        fail "fb_logrotate:[#{name}]: you can only use size or rotation not both"
-      end
-      if rotation == 'weekly' && !block['overrides']['rotate']
-         block['overrides']['rotate'] = '4'
-      end
-      if %w{hourly daily weekly monthly yearly}.include?(rotation)
-        time = rotation
-        block['overrides'].delete('rotation')
-      else
-        fail "fb_logrotate:[#{name}]: rotation #{rotation} invalid"
-      end
-    end
-    if size
-      time = "size #{size}"
-      block['overrides'].delete('size')
-    end      
-    if time == defaultrotation
-      time = nil
-    end
-    if block['overrides']['nocompress'] &&
-      node['fb_logrotate']['globals']['nocompress']
-      # redundant, remove.
-      block['overrides'].delete('nocompress')
-    end
-  end -%>
+<% node['fb_logrotate']['configs'].to_hash.each do |name, block| %>
 ## fb.fb_logrotate.configs.<%= name %>
 <%=  block['files'].join(' ') %> {
-<%   if time -%>
-  <%= time %>
+<%   if block['time'] -%>
+  <%=  block['time'] %>
 <%   end -%>
 <%   if block['overrides'] -%>
 <%     block['overrides'].keys.sort.each do |k| -%>


### PR DESCRIPTION
In
https://github.com/facebook/chef-cookbooks/commit/c5104612bf77d35474cff57e4c85ca000d848f53,
@malmond made the faulty claim that `whyrun_safe_ruby_block` was
dangerous, but he misunderstood chef ordering. It's the very very last
thing before the template (except the validator), and no one can
possibly schedule things after it, but before the template. It's the
whole reason why `whyrun_safe_ruby_block` exists.

Further, debugging templates is difficult. And logic doesn't belong in
templates. And certainly not munging of configs.

This moves the logic back to where it belongs, being careful to also
keep the logic fixes from that PR.