### PR TITLE
Fixes for fb_modprobe

### DIFF
--- a/cookbooks/fb_modprobe/resources/module.rb
+++ b/cookbooks/fb_modprobe/resources/module.rb
@@ -38,22 +38,21 @@ action_class do
     # Correctly handle built-in modules. If no parameters were supplied, we
     # just return true. If the caller supplied parameters, we fail the Chef run
     # and ask them to fix their cookbook, since we can't apply them.
-    if ::File.exist?("/sys/module/#{module_name}")
-      unless ::File.exist?("/sys/module/#{module_name}/initstate")
-        ::Chef::Log.warn(
-          "fb_modprobe called on built-in module '#{module_name}'",
-        )
-        unless params.empty?
-          fail <<-FAIL
+    if ::File.exist?("/sys/module/#{module_name}") &&
+        !::File.exist?("/sys/module/#{module_name}/initstate")
+      ::Chef::Log.warn(
+        "fb_modprobe called on built-in module '#{module_name}'",
+      )
+      unless params.empty?
+        fail <<-FAIL
           Cannot set parameters for built-in module '#{module_name}'!
           Parameters for built-in modules must be passed on the kernel cmdline.
           Prefix the parameter with the module name and a dot.
           Examples: "ipv6.autoconf=1", "mlx4_en.udp_rss=1"
-          FAIL
-        end
-
-        return True
+        FAIL
       end
+
+      return true
     end
 
     command = ['/sbin/modprobe'] + flags + [module_name] + params
@@ -83,9 +82,9 @@ action :load do
 end
 
 action :unload do
-  if !FB::Modprobe.module_loaded?(new_resource.module_name)
-    Chef::Log.debug("#{new_resource}: Module already unloaded")
-  else
+  if FB::Modprobe.module_loaded?(new_resource.module_name)
     modprobe_module(new_resource, true)
+  else
+    Chef::Log.debug("#{new_resource}: Module already unloaded")
   end
 end


### PR DESCRIPTION
First of all, `True` is not a thing in Ruby, that's python, so this code
would always raise `NameError` instead of ever passing, so code based on
this likely was never idempotent.

Second, ruby/chef lint on it.