### PR TITLE
add unified_mode true to all resources for cookbooks fb_choco, fb_hel…

### DIFF
--- a/cookbooks/fb_choco/resources/fb_choco_bootstrap.rb
+++ b/cookbooks/fb_choco/resources/fb_choco_bootstrap.rb
@@ -19,6 +19,7 @@
 resource_name :fb_choco_bootstrap
 provides :fb_choco_bootstrap
 default_action :install
+unified_mode true
 
 property :version, :kind_of => String
 

--- a/cookbooks/fb_choco/resources/fb_choco_configure.rb
+++ b/cookbooks/fb_choco/resources/fb_choco_configure.rb
@@ -19,6 +19,7 @@
 resource_name :fb_choco_configure
 provides :fb_choco_configure, :os => 'windows'
 default_action :change
+unified_mode true
 property :config,   Hash,
          :coerce => proc { |i|
                       desired = {}

--- a/cookbooks/fb_helpers/resources/gated_template.rb
+++ b/cookbooks/fb_helpers/resources/gated_template.rb
@@ -29,6 +29,7 @@ property :mode, String, :required => true
 property :gated_action, Symbol, :required => false, :default => :create
 
 default_action :manage
+unified_mode true
 
 action_class do
   # Copied from lib/chef/runner.rb

--- a/cookbooks/fb_helpers/resources/reboot.rb
+++ b/cookbooks/fb_helpers/resources/reboot.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 resource_name :fb_helpers_reboot
+unified_mode true
 
 provides :fb_helpers_reboot, :os => ['darwin', 'linux']
 

--- a/cookbooks/fb_helpers/resources/request_nw_changes.rb
+++ b/cookbooks/fb_helpers/resources/request_nw_changes.rb
@@ -17,6 +17,7 @@
 #
 
 default_action :request_nw_changes
+unified_mode true
 
 action :request_nw_changes do
   file FB::Helpers::NW_CHANGES_NEEDED do

--- a/cookbooks/fb_helpers/resources/serialize.rb
+++ b/cookbooks/fb_helpers/resources/serialize.rb
@@ -22,6 +22,7 @@ property :owner, String
 property :group, String
 property :mode, String
 property :rights, String
+unified_mode true
 
 default_action :create
 

--- a/cookbooks/fb_launchd/resources/default.rb
+++ b/cookbooks/fb_launchd/resources/default.rb
@@ -17,8 +17,8 @@
 #
 
 provides :fb_launchd, :os => 'darwin'
-
 default_action :run
+unified_mode true
 
 # Attributes that circumvent or defeat the purpose of using launchd as a node
 # API. Blacklist them so that this blows up when they're used. If you really


### PR DESCRIPTION
…pers & fb_launchd

Converging the cookbooks in this repo on a v17+ Chef client result in deprecation warning being thrown. To resolve warnings, add unified_mode true to cookbook resources. As per the documentation on unified_mode, the enablement of this feature should only cause problems under very specific circumstances (none of which should be at-play with these cookbooks).

This diff adds unified_mode true to all custom resources within the following cookbooks:
fb_choco
fb_helpers
fb_launchd