### PR TITLE
Let Fedora 36 to fetch the right iptable package (#277)

### DIFF
--- a/cookbooks/fb_helpers/README.md
+++ b/cookbooks/fb_helpers/README.md
@@ -69,6 +69,9 @@ your node.
 * `node.fedora35?`
     Is Fedora 35
 
+* `node.fedora36?`
+    Is Fedora 36
+
 * `node.redhat?`
     Is Redhat Enterprise Linux
 

--- a/cookbooks/fb_helpers/libraries/node_methods.rb
+++ b/cookbooks/fb_helpers/libraries/node_methods.rb
@@ -87,6 +87,10 @@ class Chef
       self.fedora? && self['platform_version'] == '35'
     end
 
+    def fedora36?
+      self.fedora? && self['platform_version'] == '36'
+    end
+
     def redhat?
       self['platform'] == 'redhat'
     end

--- a/cookbooks/fb_iptables/recipes/packages.rb
+++ b/cookbooks/fb_iptables/recipes/packages.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-if node.fedora34? || node.fedora35?
+if node.fedora34? || node.fedora35? || node.fedora36?
   packages = ['iptables-compat']
 else
   packages = ['iptables']


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/IT-CPE/pull/277

The current logic doesn't generate the right name for iptable packages. We should handle the iptable package as Fedora 35.

Differential Revision: D37583912

