### PR TITLE
Open-source fb_bookworm cookbook

### DIFF
--- a/cookbooks/fb_bookworm/README.md
+++ b/cookbooks/fb_bookworm/README.md
@@ -1,0 +1,29 @@
+fb_bookworm
+===========
+
+Bookworm is a program that gleans context from a Chef/Ruby codebase, which
+recognizes that Ruby source files in different directories have different
+semantic meaning to a larger program (ie Chef)
+
+It currently runs on top of the Chef Workstation Ruby, although there is
+nothing preventing running bookworm on vanilla Ruby using bundler, etc.
+
+Running bookworm
+----------------
+
+Bookworm is designed to be installed via Chef cookbook, as well as the ability
+to be run directly from the cookbook.
+
+Implementation notes - Why Rubocop for AST generation
+-----------------------------------------------------
+
+Because we wanted to use something that was already in Chef Workstation, the
+two choices were Ripper or Parser a la RuboCop (ruby_parser uses racc which has
+a C extension, but no sexp pattern matcher that I know of).
+
+Ripper is fast, but the sexp output is kind of nasty, and cleaning that up
+could be a big timesuck. Since the larger Ruby/Chef community has a bit more
+familiarity with Parser/RuboCop's node pattern matching, it'd be better to stay
+with that for now (there's no reason this couldn't be migrated later with
+helpers to translate patterns). Work could also be done to speed up RuboCop
+(ractor and async support could go a long way here).

--- a/cookbooks/fb_bookworm/files/default/bookworm.sh
+++ b/cookbooks/fb_bookworm/files/default/bookworm.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Shell script so that this can be made non-dependent on
+# chef-workstation in the future
+exec /opt/chef-workstation/embedded/bin/ruby /usr/local/lib/bookworm/bookworm.rb "$@"

--- a/cookbooks/fb_bookworm/files/default/bookworm/bookworm.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/bookworm.rb
@@ -1,0 +1,241 @@
+#!/opt/chef-workstation/embedded/bin/ruby
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'optparse'
+
+parser = ::OptionParser.new
+
+parser.banner = 'Usage: bookworm.rb [options]'
+
+# TODO(dcrosby) explicitly output to stdout?
+# parser.on(
+#   '--output TYPE',
+#   '(STUB) Configure output type for report. Options: plain (default), JSON',
+# )
+
+parser.on(
+  '--report CLASS',
+  "Give the (class) name of the report you'd like",
+)
+
+parser.on(
+  '--list-reports',
+  'Get the (class) names of available reports',
+)
+
+parser.on(
+  '--list-rules',
+  'Get the (class) names of available inferrence rules',
+)
+
+parser.separator ''
+parser.separator 'Debugging options:'
+
+# TODO(dcrosby) add verbose mode
+# parser.on(
+#   '--verbose',
+#   'Enable verbose mode',
+# )
+
+# TODO(dcrosby) get ruby-prof working
+# parser.on(
+#   '--profiler',
+#   '(WIP) Enable profiler for performance debugging',
+# )
+
+parser.on(
+  '--irb-config-step',
+  'Open IRB REPL after loading configuration',
+)
+
+parser.on(
+  '--irb-crawl-step',
+  'Open IRB REPL after crawler has run',
+)
+
+parser.on(
+  '--irb-infer-step',
+  'Open IRB REPL after inferrence has run',
+)
+
+parser.on(
+  '--irb-report-step',
+  'Open IRB REPL after report is generated',
+)
+
+options = {}
+parser.parse!(:into => options)
+
+# TODO(dcrosby) get ruby-prof working
+# if options[:profiler]
+#   require 'ruby-prof'
+#   RubyProf.start
+# end
+
+# We require the libraries *after* the profiler has a chance to start,
+# also means faster `bookworm -h` response
+require 'set'
+require_relative 'exceptions'
+require_relative 'keys'
+require_relative 'configuration'
+require_relative 'crawler'
+require_relative 'knowledge_base'
+require_relative 'infer_engine'
+require_relative 'report_builder'
+
+module Bookworm
+  class ClassLoadError < RuntimeError; end
+end
+
+# TODO(dcrosby) read CLI for config file path
+config = Bookworm::Configuration.new
+if config.source_dirs.nil? || config.source_dirs.empty?
+  fail 'configuration source_dirs cannot be empty'
+end
+
+def load_reports_dir(dir)
+  files = Dir.glob("#{dir}/*.rb")
+  files.each do |f|
+    name = Pathname(f).basename.to_s.gsub('.rb', '')
+    begin
+      Bookworm.load_report_class name, :dir => dir
+    rescue Bookworm::ClassLoadError
+      puts "Unable to load report #{f}"
+      exit(false)
+    end
+  end
+end
+
+report_src_dirs = ["#{__dir__}/reports/"]
+if Dir.exist? "#{config.system_contrib_dir}/reports"
+  report_src_dirs.append "#{config.system_contrib_dir}/reports"
+end
+
+if options[:"list-reports"]
+  report_src_dirs.each do |d|
+    load_reports_dir d
+  end
+
+  puts Bookworm::Reports.constants.map { |x|
+    "#{x}\t#{Module.const_get("Bookworm::Reports::#{x}")&.description}"
+  }.sort.join("\n")
+  exit
+end
+
+def load_rules_dir(dir)
+  files = Dir.glob("#{dir}/*.rb")
+  files.each do |f|
+    name = Pathname(f).basename.to_s.gsub('.rb', '')
+    begin
+      Bookworm.load_rule_class name, :dir => dir
+    rescue Bookworm::ClassLoadError
+      puts "Unable to load rule #{f}"
+      exit(false)
+    end
+  end
+end
+
+rule_src_dirs = ["#{__dir__}/rules/"]
+if Dir.exist? "#{config.system_contrib_dir}/rules/"
+  rule_src_dirs.append "#{config.system_contrib_dir}/rules/"
+end
+
+if options[:"list-rules"]
+  rule_src_dirs.each do |d|
+    load_reports_dir d
+  end
+  puts Bookworm::InferRules.constants.map { |x|
+    "#{x}\t#{Module.const_get("Bookworm::InferRules::#{x}")&.description}"
+  }.sort.join("\n")
+  exit
+end
+
+binding.irb if options[:"irb-config-step"] # rubocop:disable Lint/Debugger
+
+report_name = options[:report]
+unless report_name
+  puts "No report name given, take a look at bookworm --list-reports\n\n"
+  puts parser.help
+  exit(false)
+end
+report_src_dirs.each do |d|
+  begin
+    Bookworm.load_report_class report_name, :dir => d
+    break
+  rescue Bookworm::ClassLoadError
+    # puts "Unable to load report #{report_name}, take a look at bookworm --list-reports\n\n"
+  end
+end
+unless Bookworm::Reports.const_defined?(report_name.to_sym)
+  puts "Unable to load report #{report_name}, take a look at bookworm --list-reports\n\n"
+  puts parser.help
+  exit(false)
+end
+
+# To keep processing to only what is needed, the rules are specified within
+# the report. From those rules, we gather the keys that actually need to be
+# crawled (instead of crawling everything)
+# TODO(dcrosby) recursively check rules for dependency keys
+rules = Bookworm.get_report_rules(report_name)
+rules.each do |rule|
+  rule_src_dirs.each do |d|
+    begin
+      Bookworm.load_rule_class rule, :dir => d
+      break
+    rescue Bookworm::ClassLoadError
+      # puts "Unable to load rule #{rule}, take a look at bookworm --list-rules\n\n"
+    end
+  end
+  unless Bookworm::InferRules.const_defined?(rule.to_sym)
+    puts "Unable to load rule #{rule}, take a look at bookworm --list-rules\n\n"
+    puts parser.help
+    exit(false)
+  end
+end
+keys = rules.map { |r| Module.const_get("Bookworm::InferRules::#{r}")&.keys }.flatten.uniq
+
+# The crawler determines the files that need to be processed
+# It currently converts Ruby source files to AST/objects (that may change)
+processed_files = Bookworm::Crawler.new(config, :keys => keys).processed_files
+
+# The knowledge base is what we know about the files (AST, paths,
+# digested information from inference rules, etc)
+knowledge_base = Bookworm::KnowledgeBase.new(processed_files)
+
+binding.irb if options[:"irb-crawl-step"] # rubocop:disable Lint/Debugger
+
+# InferEngine takes the crawler output in the knowledge base and runs a series
+# of Infer rules against the source AST (and more) to build a knowledge base
+# around the source
+# It runs classes within the Bookworm::InferRules module namespace
+engine = Bookworm::InferEngine.new(knowledge_base, rules)
+knowledge_base = engine.knowledge_base
+
+binding.irb if options[:"irb-infer-step"] # rubocop:disable Lint/Debugger
+
+# The ReportBuilder takes the completed knowledge base and generates a report
+# with each class in the Bookworm::Reports module namespace
+
+Bookworm::ReportBuilder.new(knowledge_base, report_name)
+
+binding.irb if options[:"irb-report-step"] # rubocop:disable Lint/Debugger
+
+# TODO(dcrosby) get ruby-prof working
+# if options[:profiler]
+#   result = RubyProf.stop
+#   printer = RubyProf::FlatPrinter.new(result)
+#   printer.print($stdout)
+# end

--- a/cookbooks/fb_bookworm/files/default/bookworm/configuration.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/configuration.rb
@@ -1,0 +1,53 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module Bookworm
+  class Configuration
+    attr :source_dirs, :debug
+    attr_reader :system_contrib_dir
+
+    # Allow for programmatic configuration override
+    SYSTEM_CONFIGURATION_RUBY_FILE = '/usr/local/etc/bookworm/configuration.rb'.freeze
+    SYSTEM_CONTRIB_DIR = '/usr/local/etc/bookworm/contrib'.freeze
+
+    def initialize
+      begin
+        load SYSTEM_CONFIGURATION_RUBY_FILE
+      rescue LoadError
+        # puts "No configuration found at #{SYSTEM_CONFIGURATION_RUBY_FILE}"
+        config = {}
+      end
+      begin
+        config = YAML.load_file "#{Dir.home}/.bookworm.yml"
+      rescue StandardError
+        config = {}
+      end
+
+      @system_contrib_dir = SYSTEM_CONTRIB_DIR
+      if Bookworm::Configuration.const_defined?(:DEFAULT_SOURCE_DIRS)
+        @source_dirs ||= DEFAULT_SOURCE_DIRS
+      end
+      if Bookworm::Configuration.const_defined?(:DEFAULT_DEBUG)
+        @debug ||= DEFAULT_DEBUG
+      end
+
+      @system_contrib_dir = config['system_contrib_dir'] if config['system_contrib_dir']
+      @source_dirs = config['source_dirs'] if config['source_dirs']
+      @debug = config['debug'] if config['debug']
+
+      @source_dirs ||= []
+    end
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/crawler.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/crawler.rb
@@ -1,0 +1,80 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'rubocop'
+require 'parser/current'
+# require 'ripper'
+
+# TODO(dcrosby) move AST generation to a rule? This would allow multiple AST
+# parsers (ie ripper), which would be beneficial on heavy-duty rules It would
+# also remove overhead if only using string search/regexes in a rule (not a lot
+# of great use cases, but they exist)
+
+module Bookworm
+  class Crawler
+    attr_reader :processed_files
+
+    def initialize(config, keys: [])
+      @config = config
+
+      # TODO(dcrosby) add messages to verbose mode
+      to_crawl = {}
+      keys.each do |k|
+        v = BOOKWORM_KEYS[k]
+        to_crawl[k] = @config.source_dirs[v['source_dirs']].
+                      map { |d| Dir.glob("#{d}/#{v['glob_pattern']}") }.flatten
+      end
+      @processed_files = {}
+      to_crawl.each do |key, files|
+        instance_variable_set("@#{key}_intake_queue", files)
+        instance_variable_set("@#{key}_processed_files", {})
+        @processed_files[key] = process_paths(key)
+      end
+    end
+
+    private
+
+    def process_paths(key)
+      queue = instance_variable_get("@#{key}_intake_queue")
+      processed_files = {}
+      until queue.empty?
+        path = queue.pop
+        processed_files[path] = generate_ast(File.read(path))
+      end
+      processed_files
+    end
+
+    # Direct parser gem use is several seconds faster than using Rubocop
+    def generate_parser_ast(code)
+      Parser::CurrentRuby.parse(code)
+    end
+
+    # def generate_ripper_ast(code)
+    #   Ripper.sexp(code)[1]
+    # end
+
+    # In order to keep rules from barfing on a nil value (when no AST is
+    # generated at all from eg. an empty source code file), we supply a
+    # single node called bookworm_found_nil. It's a magic value that is
+    # 'unique enough' for our purposes
+    EMPTY_RUBOCOP_AST = ::RuboCop::AST::Node.new('bookworm_found_nil').freeze
+    def generate_rubocop_ast(code)
+      ::RuboCop::ProcessedSource.new(code, RUBY_VERSION.to_f)&.ast ||
+        EMPTY_RUBOCOP_AST
+    end
+
+    alias generate_ast generate_rubocop_ast
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/exceptions.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/exceptions.rb
@@ -1,0 +1,20 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module Bookworm
+  # ClassLoadError is where Bookworm tries to autogenerate a class from a file
+  # and cannot
+  class ClassLoadError < RuntimeError; end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/infer_base_classes.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/infer_base_classes.rb
@@ -1,0 +1,65 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'rubocop'
+module Bookworm
+  class InferRule
+    class << self
+      {
+        'description' => '',
+        'keys' => [],
+      }.each do |attribute, default_value|
+        instance_variable_set("@#{attribute}".to_sym, default_value)
+        define_method(attribute.to_sym) do |val = nil|
+          instance_variable_set("@#{attribute}", val) unless val.nil?
+          instance_variable_get("@#{attribute}")
+        end
+      end
+    end
+
+    extend RuboCop::NodePattern::Macros
+    def initialize(metadata)
+      @metadata = metadata
+      output
+    end
+
+    def to_a
+      []
+    end
+
+    def to_h
+      {}
+    end
+
+    def default_output
+      :to_a
+    end
+
+    def output
+      send(default_output)
+    end
+  end
+
+  # Initializing constant for Bookworm::InferRules
+  module InferRules; end
+
+  def self.load_rule_class(name, dir: '')
+    f = File.read "#{dir}/#{name.to_sym}.rb"
+    ::Bookworm::InferRules.const_set(name.to_sym, ::Class.new(::Bookworm::InferRule))
+    ::Bookworm::InferRules.const_get(name.to_sym).class_eval(f)
+  rescue StandardError
+    raise Bookworm::ClassLoadError
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/infer_engine.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/infer_engine.rb
@@ -1,0 +1,43 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require_relative 'knowledge_base'
+require_relative 'infer_base_classes'
+
+module Bookworm
+  class InferEngine
+    def initialize(knowledge_base, rules = [])
+      @kb = knowledge_base
+
+      rules.each do |rule|
+        process_rule(rule)
+      end
+    end
+
+    def process_rule(rule)
+      klass = Module.const_get("Bookworm::InferRules::#{rule}")
+      klass.keys.each do |key|
+        @kb.send(BOOKWORM_KEYS[key]['plural'].to_sym).each do |name, metadata|
+          out = klass.new(metadata).output
+          @kb.add_metadata(key, name, rule, out)
+        end
+      end
+    end
+
+    def knowledge_base
+      @kb
+    end
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/keys.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/keys.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Bookworm
+  # These keys are how we generalize and generate a lot of code within Bookworm
+  #
+  # VALUES
+  # metakey: A metakey isn't crawled, but is useful as a place to store information
+  # plural: The pluralized form of the key - typically used in method creation
+  # source_dirs: Specify which array of source directories to crawl
+  # glob_pattern: Specify the glob pattern for which files to crawl in source directories
+  # dont_init_kb_key: Don't initialize the keys on knowledge base creation
+  # determine_cookbook_name: Determines the cookbook name from the given path
+  # path_name_regex: A regex with a capture to determine the prettified name of the file
+  BOOKWORM_KEYS = {
+    'cookbook' => {
+      'metakey' => true,
+      'dont_init_kb_key' => true,
+    },
+    'role' => {
+      'source_dirs' => 'role_dirs',
+      'glob_pattern' => '*.rb',
+      'path_name_regex' => '([\w-]+)\.rb',
+    },
+    'metadatarb' => {
+      'glob_pattern' => '*/metadata.rb',
+      'determine_cookbook_name' => true,
+      'path_name_regex' => '(metadata\.rb)',
+    },
+    'recipe' => {
+      'determine_cookbook_name' => true,
+      'path_name_regex' => 'recipes/(.*)\.rb',
+    },
+    'attribute' => {
+      'determine_cookbook_name' => true,
+      'path_name_regex' => 'attributes/(.*)\.rb',
+    },
+    'library' => {
+      'plural' => 'libraries', # <-- the troublemaker that prompted keys first ;-)
+      'determine_cookbook_name' => true,
+      'path_name_regex' => 'libraries\/(.*)\.rb',
+    },
+    'resource' => {
+      'determine_cookbook_name' => true,
+      'path_name_regex' => 'resources/(.*)\.rb',
+    },
+    'provider' => {
+      'determine_cookbook_name' => true,
+      'path_name_regex' => 'providers/(.*)\.rb',
+    },
+  }.freeze
+
+  # Set defaults
+  BOOKWORM_KEYS.each do |k, v|
+    BOOKWORM_KEYS[k]['determine_cookbook_name'] ||= false
+    BOOKWORM_KEYS[k]['plural'] ||= "#{k}s"
+    BOOKWORM_KEYS[k]['source_dirs'] ||= 'cookbook_dirs'
+    BOOKWORM_KEYS[k]['glob_pattern'] ||= "*/#{v['plural']}/*.rb"
+  end
+
+  BOOKWORM_KEYS.freeze
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/knowledge_base.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/knowledge_base.rb
@@ -1,0 +1,60 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'pathname'
+module Bookworm
+  class KnowledgeBase
+
+    def initialize(opts)
+      BOOKWORM_KEYS.each do |k, v|
+        instance_variable_set("@#{k}", {})
+        init_keys(k, opts[k] || []) unless v['dont_init_kb_key']
+      end
+    end
+
+    # Create pluralized getter methods
+    BOOKWORM_KEYS.each do |k, v|
+      define_method(v['plural'].to_sym) do
+        instance_variable_get("@#{k}")
+      end
+    end
+
+    def add_metadata(key, name, rule, metadata)
+      instance_variable_get("@#{key}")[name][rule] = metadata
+    end
+
+    def init_keys(key, files)
+      path_name_regex = BOOKWORM_KEYS[key]['path_name_regex']
+      iv = instance_variable_get("@#{key}")
+      if BOOKWORM_KEYS[key]['determine_cookbook_name']
+        files.each do |path, ast|
+          m = path.match(%r{/?([\w-]+)/#{path_name_regex}})
+          cookbook_name = m[1]
+          file_name = m[2]
+          @cookbook[cookbook_name] ||= {}
+          iv["#{cookbook_name}::#{file_name}"] =
+            { 'path' => path, 'cookbook' => cookbook_name, 'ast' => ast }
+        end
+      else
+        files.each do |path, ast|
+          m = path.match(/#{path_name_regex}/)
+
+          file_name = m[1]
+          iv[file_name] = { 'path' => path, 'ast' => ast }
+        end
+      end
+    end
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/report_builder.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/report_builder.rb
@@ -1,0 +1,78 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'json'
+
+module Bookworm
+  class BaseReport
+    class << self
+      {
+        'description' => '',
+        'needs_rules' => [],
+      }.each do |attribute, default_value|
+        instance_variable_set("@#{attribute}".to_sym, default_value)
+        define_method(attribute.to_sym) do |val = nil|
+          instance_variable_set("@#{attribute}", val) unless val.nil?
+          instance_variable_get("@#{attribute}")
+        end
+      end
+    end
+
+    def initialize(knowledge_base)
+      @kb = knowledge_base
+      output
+    end
+
+    def to_plain
+      ''
+    end
+
+    def to_json(*_args)
+      JSON.dump({})
+    end
+
+    def default_output
+      :to_plain
+    end
+
+    def output
+      send(default_output)
+    end
+  end
+
+  # Initialize constant for Bookworm::Reports
+  module Reports; end
+
+  class ReportBuilder
+    def initialize(knowledge_base, report_name)
+      klass = Module.const_get("Bookworm::Reports::#{report_name}")
+      output = klass.new(knowledge_base).output
+
+      puts output
+    end
+  end
+  def self.get_report_rules(report_name)
+    klass = Module.const_get("Bookworm::Reports::#{report_name}")
+    klass.needs_rules
+  end
+
+  def self.load_report_class(name, dir: '')
+    f = File.read "#{dir}/#{name.to_sym}.rb"
+    ::Bookworm::Reports.const_set(name.to_sym, ::Class.new(::Bookworm::BaseReport))
+    ::Bookworm::Reports.const_get(name.to_sym).class_eval(f)
+  rescue StandardError
+    raise Bookworm::ClassLoadError
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/reports/AllReferencedRecipes.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/reports/AllReferencedRecipes.rb
@@ -1,0 +1,35 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Determines all recipes that are directly referenced by all roles'
+needs_rules ['RoleRunListRecipes', 'IncludeRecipeLiterals']
+
+def to_a
+  buffer = Set.new
+  @kb.roles.each do |_, metadata|
+    metadata['RoleRunListRecipes'].each do |role|
+      buffer << role
+    end
+  end
+  @kb.recipes.each do |_, metadata|
+    metadata['IncludeRecipeLiterals'].each do |recipe|
+      buffer << recipe
+    end
+  end
+  buffer.sort.to_a
+end
+
+def output
+  to_a
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/reports/AllRoleDescriptions.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/reports/AllRoleDescriptions.rb
@@ -1,0 +1,25 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Basic report to show extraction of description from roles'
+needs_rules ['RoleName', 'RoleDescription']
+
+def to_plain
+  buffer = ''
+  @kb.roles.sort_by { |k, _| k }.each do |name, metadata|
+    # buffer << name
+    buffer << "role: #{name} desc: #{metadata['RoleDescription']}\n"
+  end
+  buffer
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/reports/DynamicRecipeInclusion.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/reports/DynamicRecipeInclusion.rb
@@ -1,0 +1,29 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Determines all recipes using dynamic recipe inclusion (ie not string literals)'
+needs_rules ['IncludeRecipeDynamic']
+
+def to_a
+  buffer = []
+  @kb.recipes.each do |recipe, metadata|
+    buffer << recipe if metadata['IncludeRecipeDynamic']
+  end
+  buffer.sort!
+  buffer
+end
+
+def output
+  to_a
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/reports/LeafCookbooks.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/reports/LeafCookbooks.rb
@@ -1,0 +1,30 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Determine all leaf cookbooks, where no other cookbook depends on it via metadata.rb'
+needs_rules ['ExplicitMetadataDepends']
+
+def to_a
+  buffer = Set.new
+  @kb.metadatarbs.each do |_, metadata|
+    metadata['ExplicitMetadataDepends'].each do |cb|
+      buffer << cb
+    end
+  end
+  (@kb.cookbooks.keys.to_set - buffer).sort.to_a
+end
+
+def output
+  to_a
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/reports/LibraryDefinedModulesAndClassConstants.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/reports/LibraryDefinedModulesAndClassConstants.rb
@@ -1,0 +1,27 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Get modules and classes constants that are explicitly defined in library files'
+needs_rules ['LibraryDefinedClassConstants', 'LibraryDefinedModuleConstants']
+
+def output
+  buffer = ''
+  buffer << "file\tmodules\tconstants\n"
+  @kb.libraries.sort_by { |k, _| k }.each do |name, metadata|
+    # buffer << name
+    buffer << "#{name}:\t#{metadata['LibraryDefinedModuleConstants'].join(',')}" +
+              "\t#{metadata['LibraryDefinedClassConstants'].join(',')}\n"
+  end
+  buffer
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/reports/MissingReferencedRecipes.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/reports/MissingReferencedRecipes.rb
@@ -1,0 +1,61 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Determines all recipes that are directly referenced in roles and recipes' +
+            ' but were not found by the crawler'
+needs_rules ['RoleRunListRecipes', 'IncludeRecipeLiterals']
+
+def to_h
+  known_recipes = Set.new @kb.recipes.keys
+  missing = { 'roles' => {}, 'recipes' => {} }
+  @kb.roles.each do |role, metadata|
+    metadata['RoleRunListRecipes'].each do |recipe|
+      unless known_recipes.include? recipe
+        missing['roles'][role] ||= []
+        missing['roles'][role].append recipe
+      end
+    end
+  end
+  @kb.recipes.each do |kbrecipe, metadata|
+    metadata['IncludeRecipeLiterals'].each do |recipe|
+      unless known_recipes.include? recipe
+        missing['recipes'][kbrecipe] ||= []
+        missing['recipes'][kbrecipe].append recipe
+      end
+    end
+  end
+  missing
+end
+
+def to_plain
+  hsh = to_h
+  buffer = ''
+  if hsh['roles'].empty?
+    buffer << "No missing recipes coming from the roles files\n"
+  else
+    buffer << "Roles:\n"
+    hsh['roles'].each do |role, recipes|
+      buffer << "\t#{role}\t#{recipes.join(', ')}\n"
+    end
+  end
+  if hsh['recipes'].empty?
+    buffer << 'No missing recipes coming from the recipe files'
+  else
+    buffer << "Recipes:\n"
+    hsh['recipes'].each do |kbrecipe, recipes|
+      buffer << "\t#{kbrecipe}\t#{recipes.join(', ')}\n"
+    end
+  end
+  buffer
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/reports/NoParsedRuby.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/reports/NoParsedRuby.rb
@@ -1,0 +1,46 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Ruby files which are empty, comments-only, ' +
+   'or unparseable by RuboCop'
+needs_rules ['NoParsedRuby']
+
+def to_h
+  no_parsed_ruby = {}
+  Bookworm::InferRules::NoParsedRuby.keys.each do |key|
+    plural = BOOKWORM_KEYS[key]['plural']
+    no_parsed_ruby[plural] = []
+    @kb.send(plural.to_sym).each do |k, metadata|
+      no_parsed_ruby[plural].append(k) if metadata['NoParsedRuby']
+    end
+  end
+  no_parsed_ruby
+end
+
+def to_plain
+  hsh = to_h
+  buffer = ''
+  Bookworm::InferRules::NoParsedRuby.keys.each do |key|
+    plural = BOOKWORM_KEYS[key]['plural']
+    if hsh[plural].empty?
+      buffer << "No non-AST #{plural} files\n"
+    else
+      buffer << "#{plural.capitalize}:\n"
+      hsh[plural].sort.each do |keys|
+        buffer << "\t#{keys}\n"
+      end
+    end
+  end
+  buffer
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/reports/RecipesAssigningConstants.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/reports/RecipesAssigningConstants.rb
@@ -1,0 +1,27 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Determine all recipes that are assigning a constant in the recipe file'
+needs_rules ['RecipeConstantAssignments']
+
+def output
+  buffer = ''
+
+  @kb.recipes.each do |name, metadata|
+    unless metadata['RecipeConstantAssignments'].empty?
+      buffer << "#{name} #{metadata['RecipeConstantAssignments'].join(', ')}\n"
+    end
+  end
+  buffer
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/reports/RoleRecipeEntrypoints.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/reports/RoleRecipeEntrypoints.rb
@@ -1,0 +1,30 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Determines all recipes that are directly referenced by all roles'
+needs_rules ['RoleRunListRecipes']
+
+def to_a
+  buffer = Set.new
+  @kb.roles.each do |_, metadata|
+    metadata['RoleRunListRecipes'].each do |recipe|
+      buffer << recipe
+    end
+  end
+  buffer.sort.to_a
+end
+
+def output
+  to_a
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/reports/RoleReferencedRoles.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/reports/RoleReferencedRoles.rb
@@ -1,0 +1,30 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Determine roles which are directly referenced by other roles'
+needs_rules ['RoleExplicitRoles']
+
+def to_a
+  buffer = Set.new
+  @kb.roles.each do |_, metadata|
+    metadata['RoleExplicitRoles'].each do |role|
+      buffer << role
+    end
+  end
+  buffer.sort.to_a
+end
+
+def output
+  to_a
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/rules/ExplicitMetadataDepends.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/rules/ExplicitMetadataDepends.rb
@@ -1,0 +1,22 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Extract depends usage from a cookbook\'s metadata.rb'
+keys ['metadatarb']
+
+def_node_search :explicit_depends, '`(send nil? :depends (str $_))'
+
+def to_a
+  explicit_depends(@metadata['ast']).to_a.uniq
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/rules/IncludeRecipeDynamic.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/rules/IncludeRecipeDynamic.rb
@@ -1,0 +1,24 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Extracts recipes that do not use include_recipe with a string literal'
+keys ['recipe']
+
+def_node_search :include_recipe_dynamic, '`(send nil? :include_recipe $_)'
+
+def output
+  include_recipe_dynamic(@metadata['ast']).any? do |x|
+    !(x.is_a?(RuboCop::AST::StrNode) && x.str_type?)
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/rules/IncludeRecipeLiterals.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/rules/IncludeRecipeLiterals.rb
@@ -1,0 +1,37 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Extracts recipes that are used by include_recipe with string literals'
+keys ['recipe']
+
+def_node_search :include_recipe_string_literals, '`(send nil? :include_recipe (str $_))'
+
+def to_a
+  arr = []
+  include_recipe_string_literals(@metadata['ast']).each do |x|
+    arr << x
+  end
+  return [] if arr.empty?
+  arr.map! do |x|
+    if x.start_with?('::')
+      "#{@metadata['cookbook']}#{x}"
+    elsif !x.include?('::')
+      "#{x}::default"
+    else
+      x
+    end
+  end
+  arr.uniq!
+  arr.sort!
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/rules/LibraryDefinedClassConstants.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/rules/LibraryDefinedClassConstants.rb
@@ -1,0 +1,22 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Get all class constants - it does *not* qualify the namespace'
+keys ['library']
+
+def_node_search :defined_class_constants, '`(class (const nil? $_) ...)'
+
+def to_a
+  defined_class_constants(@metadata['ast']).to_a.uniq
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/rules/LibraryDefinedModuleConstants.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/rules/LibraryDefinedModuleConstants.rb
@@ -1,0 +1,22 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Get all module constants - it does *not* qualify the namespace'
+keys ['library']
+
+def_node_search :defined_module_constants, '`(module (const nil? $_) ...)'
+
+def to_a
+  defined_module_constants(@metadata['ast']).to_a.uniq
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/rules/NoParsedRuby.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/rules/NoParsedRuby.rb
@@ -1,0 +1,30 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Ruby files which are empty, comments-only, ' +
+            'or unparseable by RuboCop'
+keys %w{
+  attribute
+  library
+  metadatarb
+  provider
+  recipe
+  resource
+  role
+}
+
+# See note in crawler.rb about EMPTY_RUBOCOP_AST constant
+def output
+  @metadata['ast'] == Bookworm::Crawler::EMPTY_RUBOCOP_AST
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/rules/RecipeConstantAssignments.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/rules/RecipeConstantAssignments.rb
@@ -1,0 +1,22 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Extract constants that are defined in recipes'
+keys ['recipe']
+
+def_node_search :constants_assigned, '`(casgn nil? $_ ...)'
+
+def to_a
+  constants_assigned(@metadata['ast']).to_a.uniq.sort
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/rules/RoleDescription.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/rules/RoleDescription.rb
@@ -1,0 +1,22 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Scrapes description from role file'
+keys ['role']
+
+def_node_matcher :role_description, '`(send nil? :description (str $_))'
+
+def output
+  role_description @metadata['ast']
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/rules/RoleExplicitRoles.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/rules/RoleExplicitRoles.rb
@@ -1,0 +1,29 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Scrapes explicit roles in a role files run list'
+keys ['role']
+
+def_node_matcher :role_run_list, '`(send nil? :run_list (str $_)*)'
+
+def output
+  arr = role_run_list @metadata['ast']
+  roles = []
+  arr&.each do |item|
+    roles << item if item.start_with? 'role['
+  end
+  # TODO(dcrosby) better regex here
+  roles.map! { |x| x.gsub(/^role\[/, '') }
+  roles.map { |x| x.gsub(/\]$/, '') }
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/rules/RoleName.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/rules/RoleName.rb
@@ -1,0 +1,22 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Scrapes name from role file'
+keys ['role']
+
+def_node_matcher :role_name, '`(send nil? :name (str $_))'
+
+def output
+  role_name @metadata['ast']
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/rules/RoleRunList.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/rules/RoleRunList.rb
@@ -1,0 +1,22 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Scrapes run list from role file'
+keys ['role']
+
+def_node_matcher :role_run_list, '`(send nil? :run_list (str $_)*)'
+
+def output
+  role_run_list @metadata['ast']
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/rules/RoleRunListRecipes.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/rules/RoleRunListRecipes.rb
@@ -1,0 +1,29 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+description 'Scrapes run list recipes from role file'
+keys ['role']
+
+def_node_matcher :role_run_list, '`(send nil? :run_list (str $_)*)'
+
+def output
+  arr = role_run_list @metadata['ast']
+  recipes = []
+  arr&.each do |item|
+    recipes << item unless item.start_with? 'role['
+  end
+
+  recipes.map! { |x| x.start_with?('recipe[') ? x.match(/recipe\[(.*)\]/)[1] : x }
+  recipes.map { |x| x.include?('::') ? x : "#{x}::default" }
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/spec/knowledge_base_spec.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/spec/knowledge_base_spec.rb
@@ -1,0 +1,69 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require_relative 'spec_helper'
+require_relative '../keys'
+require_relative '../knowledge_base'
+
+describe Bookworm::KnowledgeBase do
+  it 'holds all yer roles' do
+    kb = Bookworm::KnowledgeBase.new({
+                                       'role' => [['foo.rb', '(ast)']],
+                                     })
+    expect(kb.roles).to eq({ 'foo' => { 'path' => 'foo.rb', 'ast'=> '(ast)' } })
+  end
+  it 'holds all yer metadatarbs' do
+    kb = Bookworm::KnowledgeBase.new({
+                                       'metadatarb' => [['thing/metadata.rb', '(ast)']],
+                                     })
+    expect(kb.cookbooks).to eq({ 'thing' => {} })
+    expect(kb.metadatarbs).to eq({ 'thing::metadata.rb' => {
+                                   'path' => 'thing/metadata.rb',
+      'cookbook' => 'thing',
+      'ast' => '(ast)',
+                                 } })
+  end
+  it 'holds all yer recipes' do
+    kb = Bookworm::KnowledgeBase.new({
+                                       'recipe'=> [['thing/recipes/default.rb', '(ast)']],
+                                     })
+    expect(kb.recipes).to eq({ 'thing::default' => {
+                               'path' => 'thing/recipes/default.rb',
+      'cookbook' => 'thing',
+      'ast' => '(ast)',
+                             } })
+  end
+  it 'holds all yer attributes' do
+    kb = Bookworm::KnowledgeBase.new(
+      {
+        'attribute' => [['thing/attributes/default.rb', '(ast)']],
+      },
+    )
+    expect(kb.attributes).to eq({ 'thing::default' => {
+                                  'path' => 'thing/attributes/default.rb',
+      'cookbook' => 'thing',
+      'ast' => '(ast)',
+                                } })
+  end
+  it 'holds all yer libraries' do
+    kb = Bookworm::KnowledgeBase.new(
+      { 'library' => [['thing/libraries/default.rb', '(ast)']] },
+    )
+    expect(kb.libraries).to eq({ 'thing::default' => {
+                                 'path' => 'thing/libraries/default.rb',
+      'cookbook' => 'thing',
+      'ast' => '(ast)',
+                               } })
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/ExplicitMetadataDepends_spec.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/ExplicitMetadataDepends_spec.rb
@@ -1,0 +1,30 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require_relative './helper'
+
+describe Bookworm::InferRules::ExplicitMetadataDepends do
+  let(:ast) do
+    generate_ast(<<~RUBY)
+    name 'fake_cookbook'
+    version '0.0.1'
+    depends 'fake_cookbook1'
+    depends 'fake_cookbook2'
+  RUBY
+  end
+  it 'captures the metadata.rb dependencies' do
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.to_a).to eq(['fake_cookbook1', 'fake_cookbook2'])
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/IncludeRecipeDynamic_spec.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/IncludeRecipeDynamic_spec.rb
@@ -1,0 +1,53 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require_relative './helper'
+
+describe Bookworm::InferRules::IncludeRecipeDynamic do
+  it 'returns false on no AST' do
+    ast = generate_ast(<<~RUBY)
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq(false)
+  end
+  it 'returns false where no include_recipe found' do
+    ast = generate_ast(<<~RUBY)
+      file 'just_a_plain_old_resource'
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq(false)
+  end
+  it 'returns false where no dynamic include_recipe found' do
+    ast = generate_ast(<<~RUBY)
+      include_recipe '::fake_recipe'
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq(false)
+  end
+  it 'returns true where include_recipe with variable found' do
+    ast = generate_ast(<<~RUBY)
+    var = '::fake_recipe'
+    include_recipe var
+  RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq(true)
+  end
+  it 'returns true where include_recipe with interpolated string found' do
+    ast = generate_ast(<<~RUBY)
+    include_recipe "\#{cookbook_name}::fake_recipe"
+  RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq(true)
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/IncludeRecipeLiterals_spec.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/IncludeRecipeLiterals_spec.rb
@@ -1,0 +1,59 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require_relative './helper'
+
+describe Bookworm::InferRules::IncludeRecipeLiterals do
+  it 'returns empty array when no include_recipe' do
+    ast = generate_ast(<<~RUBY)
+      file 'just_a_plain_old_resource'
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq([])
+  end
+  it 'returns qualified recipe name with :: prefix sugar' do
+    ast = generate_ast(<<~RUBY)
+      include_recipe '::fake_recipe'
+    RUBY
+    rule = described_class.new({
+                                 'cookbook' => 'fake_cookbook',
+      'ast' => ast,
+                               })
+    expect(rule.output).to eq(['fake_cookbook::fake_recipe'])
+  end
+  it 'returns qualified recipe name with implied default recipe' do
+    ast = generate_ast(<<~RUBY)
+      include_recipe 'fake_cookbook'
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq(['fake_cookbook::default'])
+  end
+  it 'returns qualified recipe name with qualified recipe name' do
+    ast = generate_ast(<<~RUBY)
+      include_recipe 'fake_cookbook::fake_recipe'
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq(['fake_cookbook::fake_recipe'])
+  end
+  it 'handles multiple include_recipe calls' do
+    ast = generate_ast(<<~RUBY)
+      file 'stub' # <- some code to test AST recursion
+      include_recipe 'fake_cookbook::foo'
+      include_recipe 'fake_cookbook::bar'
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    # Note - output is sorted
+    expect(rule.output).to eq(['fake_cookbook::bar', 'fake_cookbook::foo'])
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/LibraryDefinedClassConstants_spec.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/LibraryDefinedClassConstants_spec.rb
@@ -1,0 +1,50 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require_relative './helper'
+
+describe Bookworm::InferRules::LibraryDefinedClassConstants do
+  it 'returns empty array when no class defined' do
+    ast = generate_ast(<<~RUBY)
+      true
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq([])
+  end
+  it 'captures the top-level class name' do
+    ast = generate_ast(<<~RUBY)
+      class Foo ; end
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq([:Foo])
+  end
+  it 'captures class name inside module' do
+    ast = generate_ast(<<~RUBY)
+      module Bar
+        class Foo ; end
+      end
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq([:Foo])
+  end
+  it 'captures nested class names' do
+    ast = generate_ast(<<~RUBY)
+      class Bar
+        class Foo ; end
+      end
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq([:Bar, :Foo])
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/LibraryDefinedModuleConstants_spec.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/LibraryDefinedModuleConstants_spec.rb
@@ -1,0 +1,50 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require_relative './helper'
+
+describe Bookworm::InferRules::LibraryDefinedModuleConstants do
+  it 'returns empty array when no module defined' do
+    ast = generate_ast(<<~RUBY)
+      true
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq([])
+  end
+  it 'captures the top-level module name' do
+    ast = generate_ast(<<~RUBY)
+      module Foo ; end
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq([:Foo])
+  end
+  it 'captures module name inside module' do
+    ast = generate_ast(<<~RUBY)
+      module Bar
+        class Foo ; end
+      end
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq([:Bar])
+  end
+  it 'captures nested module names' do
+    ast = generate_ast(<<~RUBY)
+      module Bar
+        module Foo ; end
+      end
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq([:Bar, :Foo])
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/NoParsedRuby_spec.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/NoParsedRuby_spec.rb
@@ -1,0 +1,36 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require_relative './helper'
+
+describe Bookworm::InferRules::NoParsedRuby do
+  let(:no_ast) do
+    generate_ast(<<~RUBY)
+      # some silly comment
+    RUBY
+  end
+  let(:has_ast) do
+    generate_ast(<<~RUBY)
+    name "fake_role"
+    RUBY
+  end
+  it 'returns true if does not have ast' do
+    rule = described_class.new({ 'ast' => no_ast })
+    expect(rule.output).to eq(true)
+  end
+  it 'returns false if has ast' do
+    rule = described_class.new({ 'ast' => has_ast })
+    expect(rule.output).to eq(false)
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/RecipeConstantAssignments_spec.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/RecipeConstantAssignments_spec.rb
@@ -1,0 +1,41 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require_relative './helper'
+
+describe Bookworm::InferRules::RecipeConstantAssignments do
+  it 'does not capture normal variables' do
+    ast= generate_ast(<<~RUBY)
+      foo = "bar"
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq([])
+  end
+  it 'captures a single constant assignment' do
+    ast = generate_ast(<<~RUBY)
+      Foo = "bar"
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq([:Foo])
+  end
+  it 'captures a multiple constant assignments' do
+    ast = generate_ast(<<~RUBY)
+      FooB = "bar"
+      FooA = "bar"
+      FooC = "bar"
+    RUBY
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq([:FooA, :FooB, :FooC])
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/RoleDescription_spec.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/RoleDescription_spec.rb
@@ -1,0 +1,27 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require_relative './helper'
+
+describe Bookworm::InferRules::RoleDescription do
+  let(:ast) do
+    generate_ast(<<~RUBY)
+    description "This is a fake role"
+  RUBY
+  end
+  it 'captures the role description' do
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq('This is a fake role')
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/RoleExplicitRoles_spec.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/RoleExplicitRoles_spec.rb
@@ -1,0 +1,33 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require_relative './helper'
+
+describe Bookworm::InferRules::RoleExplicitRoles do
+  let(:ast) do
+    generate_ast(<<~RUBY)
+    name "fake role"
+    description "This is a fake role"
+
+    run_list(
+      'role[foo]',
+      'recipe[bar]',
+    )
+  RUBY
+  end
+  it 'captures the roles from the run list' do
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq(['foo'])
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/RoleName_spec.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/RoleName_spec.rb
@@ -1,0 +1,27 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require_relative './helper'
+
+describe Bookworm::InferRules::RoleName do
+  let(:ast) do
+    generate_ast(<<~RUBY)
+    name "fake_role"
+  RUBY
+  end
+  it 'captures the role name' do
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq('fake_role')
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/RoleRunListRecipes_spec.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/RoleRunListRecipes_spec.rb
@@ -1,0 +1,34 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require_relative 'helper'
+
+describe Bookworm::InferRules::RoleRunListRecipes do
+  let(:ast) do
+    generate_ast(<<~RUBY)
+    name "fake role"
+    description "This is a fake role"
+
+    run_list(
+      'role[foo]',
+      'recipe[bar]',
+      'recipe[baz::packages]',
+    )
+  RUBY
+  end
+  it 'captures the recipe names' do
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq(['bar::default', 'baz::packages'])
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/RoleRunList_spec.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/RoleRunList_spec.rb
@@ -1,0 +1,33 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require_relative './helper'
+
+describe Bookworm::InferRules::RoleRunList do
+  let(:ast) do
+    generate_ast(<<~RUBY)
+    name "fake role"
+    description "This is a fake role"
+
+    run_list(
+      'role[foo]',
+      'recipe[bar]',
+    )
+  RUBY
+  end
+  it 'captures the run list from a role' do
+    rule = described_class.new({ 'ast' => ast })
+    expect(rule.output).to eq(['role[foo]', 'recipe[bar]'])
+  end
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/helper.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/spec/rules/helper.rb
@@ -1,0 +1,32 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require 'pathname'
+require_relative '../../crawler'
+require_relative '../../exceptions'
+require_relative '../../infer_engine'
+
+# Load all rule files
+files = Dir.glob("#{__dir__}/../../rules/*.rb")
+files.each do |f|
+  name = Pathname(f).basename.to_s.gsub('.rb', '')
+  ::Bookworm.load_rule_class name, :dir => "#{__dir__}/../../rules"
+end
+
+require_relative '../spec_helper'
+
+def generate_ast(str)
+  ::RuboCop::ProcessedSource.new(str, RUBY_VERSION.to_f)&.ast ||
+    ::Bookworm::Crawler::EMPTY_RUBOCOP_AST
+end

--- a/cookbooks/fb_bookworm/files/default/bookworm/spec/spec_helper.rb
+++ b/cookbooks/fb_bookworm/files/default/bookworm/spec/spec_helper.rb
@@ -1,0 +1,23 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require 'rspec'
+require 'rspec/support'
+require 'rspec/support/differ'
+RSpec.configure do |config|
+  # Basic configuration
+  config.run_all_when_everything_filtered = true
+  config.filter_run(:focus)
+  config.order = :random
+end

--- a/cookbooks/fb_bookworm/metadata.rb
+++ b/cookbooks/fb_bookworm/metadata.rb
@@ -1,0 +1,23 @@
+# vim: syntax=ruby:expandtab:shiftwidth=2:softtabstop=2:tabstop=2
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name 'fb_bookworm'
+maintainer 'Meta Platforms, Inc.'
+maintainer_email 'noreply@facebook.com'
+license 'Apache-2.0'
+description 'Installs bookworm tool'
+version '0.1.0'
+
+depends 'fb_helpers'

--- a/cookbooks/fb_bookworm/recipes/default.rb
+++ b/cookbooks/fb_bookworm/recipes/default.rb
@@ -1,0 +1,30 @@
+# Copyright (c) 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+cookbook_file '/usr/local/bin/bookworm' do
+  source 'bookworm.sh'
+  owner node.root_user
+  group node.root_group
+  mode 0755
+end
+
+remote_directory '/usr/local/lib/bookworm' do
+  source 'bookworm'
+  purge true
+  owner node.root_user
+  group node.root_group
+  mode 0755
+end


### PR DESCRIPTION
Bookworm is a tool that leverages RuboCop AST parsing to query Chef codebases, extracting information and finding relations between cookbooks

fbshipit-source-id: 46df5e0e50b39bed2331842a5d6dedfaba24d2fd