### PR TITLE
Fix bug in `sync_fb_cookbooks`

### DIFF
--- a/scripts/sync_fb_cookbooks.sh
+++ b/scripts/sync_fb_cookbooks.sh
@@ -107,7 +107,7 @@ fi
 
 mode=''
 cookbook=''
-while getopts c:dhipsu: opt; do
+while getopts c:dhi:psu: opt; do
     case $opt in
         c)
             cookbook="$OPTARG"


### PR DESCRIPTION
Fix bug in `sync_fb_cookbooks`

Summary:

-i takes an argument, but the `getopts` call didn't specify that.

Test Plan:

Used it to sync cookbooks

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/chef-cookbooks/pull/217).
* __->__ #217
