### PR TITLE
[github] Update CI to Chef 16, drop Ruby 2.5/2.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         os: ${{ matrix.os }}
       env:
         CHEF_LICENSE: accept-no-persist
-        CHEF_VERSION: 14.15.6
+        CHEF_VERSION: 16.18.0
   shellcheck:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0, 3.1]
+        ruby: ['2.7', '3.0', '3.1']
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'chef', '~> 14'
+gem 'chef', '~> 16'
 gem 'cookstyle', '= 7.32.1'
 gem 'rspec', '= 3.10'
 gem 'rubocop', '= 1.25.1'


### PR DESCRIPTION
The end result of this is working rubocop/chefspec tests (which have been broken for a while now, so I'm happy to be seeing green). Test Kitchen fixes are out of scope for this one, since there's a bunch more work in that area. 