### PR TITLE
fb_apt: Add ability to log output of `apt-get update`

### DIFF
--- a/cookbooks/fb_apt/README.md
+++ b/cookbooks/fb_apt/README.md
@@ -22,6 +22,7 @@ Attributes
 * node['fb_apt']['want_source']
 * node['fb_apt']['preserve_unknown_keyrings']
 * node['fb_apt']['allow_modified_pkg_keyrings']
+* node['fb_apt']['apt_update_log_path']
 
 Usage
 -----
@@ -107,3 +108,8 @@ As mentioned above, `fb_apt` can assemble the basic sources for you. It uses
 the LSB "codename" of the current systemd to build the URLs. In the event you
 want to use Chef to upgrade across distros, however, you can set
 `node['fb_apt']['distro']` to the appropriate name and it will be used instead.
+
+### Logging `apt-get update`
+Set `node['fb_apt']['apt_update_log_path']` to log stdout and stderr of the
+`apt-get update` command invoked by this cookbook. This may be useful for
+debugging purposes. The caller must handle log rotation.

--- a/cookbooks/fb_apt/attributes/default.rb
+++ b/cookbooks/fb_apt/attributes/default.rb
@@ -38,6 +38,7 @@ default['fb_apt'] = {
   'want_source' => false,
   'preserve_unknown_keyrings' => false,
   'allow_modified_pkg_keyrings' => false,
+  'apt_update_log_path' => nil,
 }
 # fb_apt must be defined for this to work...
 keys = FB::Apt.get_official_keyids(node).map { |id| [id, nil] }.to_h

--- a/cookbooks/fb_apt/recipes/default.rb
+++ b/cookbooks/fb_apt/recipes/default.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+require 'shellwords'
+
 unless node.debian? || node.ubuntu?
   fail 'fb_apt is only supported on Debian and Ubuntu.'
 end
@@ -94,7 +96,11 @@ fb_apt_sources_list 'populate sources list' do
 end
 
 execute 'apt-get update' do
-  command 'apt-get update'
+  command(lazy do
+    log_path = node['fb_apt']['apt_update_log_path']
+    cmd_suffix = " >>#{Shellwords.shellescape(log_path)} 2>&1" if log_path
+    "apt-get update#{cmd_suffix}"
+  end)
   action :nothing
 end
 


### PR DESCRIPTION
We're using `Debug::pkgAcquire::Worker` and this patch to debug https://bugs.launchpad.net/ubuntu/+source/apt/+bug/2003851 which we run into occasionally.