### PR TITLE
Fix fb_systemd on hosts without networkd

### DIFF
--- a/cookbooks/fb_systemd/recipes/networkd.rb
+++ b/cookbooks/fb_systemd/recipes/networkd.rb
@@ -19,6 +19,7 @@
 #
 
 fb_helpers_gated_template '/etc/systemd/networkd.conf' do
+  only_if { node['fb_systemd']['networkd']['enable'] }
   allow_changes node.nw_changes_allowed?
   source 'systemd.conf.erb'
   owner node.root_user


### PR DESCRIPTION
Fix fb_systemd on hosts without networkd

Summary:

If you don't use networkd (and `fb_networkd`), then this code in `fb_system::networkd`

Test Plan:

@anitazha did some testing of this internal to Meta already, plus
I've rolled this out to the SCALE infra
