### PR TITLE
feat: lazy timer commands

### DIFF
--- a/cookbooks/fb_timers/README.md
+++ b/cookbooks/fb_timers/README.md
@@ -65,7 +65,8 @@ Required fields:
   when you want your job to run. Corresponds to the `OnCalendar` field of the
   systemd timer. See below for helpers to generate common calendar patterns.
 * `command`: The command to run. Corresponds to the `ExecStart` field of the
-  systemd service.
+  systemd service. Specify a Proc to lazily evaluate the command string, useful
+  for an attribute-driven command.
 * `commands`: The commands to run. Will generate several `ExecStart` lines.
   Useful if you want to run multiple commands in sequence, without forking to
   bash. Mixing `commands` and `command` will produce a warning, but the

--- a/cookbooks/fb_timers/spec/default_spec.rb
+++ b/cookbooks/fb_timers/spec/default_spec.rb
@@ -156,6 +156,10 @@ recipe 'fb_timers::default', :unsupported => [:mac_os_x] do |tc|
             'command' => '/usr/local/bin/foobar.sh',
             'timer_options' => { 'OnBootSec' => '1s' },
           },
+          'lazy' => {
+            'calendar' => '*:0/15:0',
+            'command' => proc { '/usr/local/bin/foobar.sh' },
+          },
         }
       end
     end

--- a/cookbooks/fb_timers/spec/fixtures/default/lazy.service
+++ b/cookbooks/fb_timers/spec/fixtures/default/lazy.service
@@ -1,0 +1,12 @@
+# This file managed by chef.
+# Local changes to this file will be overwritten.
+
+[Unit]
+Description=Run scheduled task lazy
+After=network.target
+
+[Service]
+Type=oneshot
+Slice=system-timers-lazy.slice
+ExecStart=/usr/local/bin/foobar.sh
+TimeoutStopSec=90s

--- a/cookbooks/fb_timers/spec/fixtures/default/lazy.timer
+++ b/cookbooks/fb_timers/spec/fixtures/default/lazy.timer
@@ -1,0 +1,15 @@
+# This file managed by chef.
+# Local changes to this file will be overwritten.
+
+[Unit]
+Description=Run scheduled task lazy
+
+[Install]
+WantedBy=timers.target
+
+[Timer]
+OnCalendar=*:0/15:0
+AccuracySec=1s
+Persistent=false
+RandomizedDelaySec=0s
+Unit=lazy.service

--- a/cookbooks/fb_timers/templates/default/service.erb
+++ b/cookbooks/fb_timers/templates/default/service.erb
@@ -26,7 +26,7 @@ EnvironmentFile=<%= @conf['envfile'] %>
 Slice=system-timers-<%= @conf['name'] %>.slice
 <% end %>
 <% @conf['commands'].each do |command| %>
-ExecStart=<%= command %>
+ExecStart=<%= if command.instance_of?(Proc) then command.call() else command end %>
 <% end %>
 <% if @conf['timeout'] %>
 TimeoutStartSec=<%= @conf['timeout'] %>


### PR DESCRIPTION
Before this commit, it was not possible to lazily declare an `fb_timers` entry that utilized a node attribute inside the command.

After this commit, specifying a `Proc` for `command` or entries in `commands` will cause `fb_timers` to evaluate the proc when rendering the service template.

This is related to https://github.com/facebook/chef-cookbooks/issues/233. I can't exactly recall where we landed on whether it was acceptable to add `Proc` support to cookbooks, but this particular example has come up enough times that I feel that it's worth enabling.

(I couldn't run these tests locally, so I might need to iterate a bit if I made a mistake)

