### PR TITLE
Fix fb_apache for Debian-family

### DIFF
--- a/cookbooks/fb_apache/recipes/default.rb
+++ b/cookbooks/fb_apache/recipes/default.rb
@@ -46,7 +46,11 @@ apache_version =
     when 'ubuntu'
       node['platform_version'].to_f >= 13.10 ? '2.4' : '2.2'
     when 'debian'
-      node['platform_version'].to_f >= 8.0 ? '2.4' : '2.2'
+      if node['platform_version'].end_with?('/sid')
+        '2.4'
+      else
+        node['platform_version'].to_f >= 8.0 ? '2.4' : '2.2'
+      end
     else
       '2.4'
     end

--- a/cookbooks/fb_apache/resources/verify_configs.rb
+++ b/cookbooks/fb_apache/resources/verify_configs.rb
@@ -16,26 +16,41 @@ action :verify do
   # configurations in the same and then run validator on it. This way,
   # validation happens on new configurations without touching the live ones.
   ::Dir.mktmpdir do |tdir|
-    Chef::Log.
-      debug("fb_apache: copy from '#{new_resource.httpdir}' to '#{tdir}'")
+    Chef::Log.debug(
+      "fb_apache: copy from '#{new_resource.httpdir}' to '#{tdir}'"
+    )
     FileUtils.cp_r("#{new_resource.httpdir}/.", tdir)
 
     # This is some trickery. We change the "ServerRoot" to the temp
     # folder we created.
     #
-    # Context - `httpd.conf` is the main config that loads other modules and
-    # configs. `httpd.conf` lives in the canonical location called "server
-    # root". `httpd` cli allows one to change server root using `-d` option,
-    # however that only changes the location of where it finds `httd.conf`; it
-    # does not change the paths from which "other" configs are loaded. To really
-    # change the paths where other configs are loaded we have to change the
-    # "ServerRoot" in `httpd.conf` from the canonical `/etc/httpd` to
+
+    # Context - `httpd.conf` (or `apache2.conf`) is the main config that loads
+    # other modules and configs. It lives in the canonical location called
+    # "server root". `httpd` cli allows one to change server root using `-d`
+    # option, however that only changes the location of where it finds the
+    # config; it does not change the paths from which "other" configs are
+    # loaded. To really change the paths where other configs are loaded we have
+    # to change the "ServerRoot" in the config from the canonical directory to
     # `/tmp/<whatever>`. This way, all the other configurations in the temp
     # folder are correctly loaded and verified.
     Chef::Log.debug("fb_apache: modify contents of '#{tdir}/conf/httpd.conf'")
-    file = Chef::Util::FileEdit.new("#{tdir}/conf/httpd.conf")
-    file.search_file_replace_line(%r{^ServerRoot "/etc/httpd"$},
-                                  "ServerRoot \"#{tdir}\"") ||
+    config_file = value_for_platform_family(
+      ['rhel', 'fedora'] => 'conf/httpd.conf',
+      'debian' => 'apache2.conf',
+    )
+    file = Chef::Util::FileEdit.new("#{tdir}/#{config_file}")
+    # If it's specified, change it, otherwise, change the commented-out
+    # version (if it's the default, it stays commented out), and un-comment
+    # it out.
+    file.search_file_replace_line(
+      %r{^ServerRoot "#{new_resource.httpdir}"$},
+      "ServerRoot \"#{tdir}\""
+    ) ||
+      file.search_file_replace_line(
+        %r{^#ServerRoot "#{new_resource.httpdir}"$},
+        "ServerRoot \"#{tdir}\""
+      ) ||
       fail('Apache validation failed. Cannot find `ServerRoot /etc/httpd`')
     file.write_file
 


### PR DESCRIPTION
The `verify_configs` custom resource wasn't using the passed-in httpdir
and was assuming RHEL-like httpdir and config file name. Fixed both.

Also, on Debian sid, the version-matching failed, so fixed that.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
