### PR TITLE
fb_apache: Add 'manage_service' configurable

### DIFF
--- a/cookbooks/fb_apache/README.md
+++ b/cookbooks/fb_apache/README.md
@@ -8,6 +8,7 @@ Requirements
 Attributes
 ----------
 * node['fb_apache']['manage_packages']
+* node['fb_apache']['manage_service']
 * node['fb_apache']['sites'][$SITE][$CONFIG]
 * node['fb_apache']['sysconfig'][$KEY]
 * node['fb_apache']['sysconfig']['_extra_lines']
@@ -22,16 +23,26 @@ Attributes
 Usage
 -----
 ### Packages
-My default `fb_apache` will install and keep up to date the `apache` and
+By default `fb_apache` will install and keep up to date the `apache` and
 `mod_ssl` packages as relevant for your distribution. If you'd prefer to do
 this on your own then you can set `node['fb_apache']['manage_packages']` to
-`false`.
+`false` and get the set of packages by calling `FB::Apache.packages` - but
+you must do this at runtime (i.e. in a `lazy` block) if you want it to take
+into account your `node['fb_apache']['modules']` settings.
 
 For modules, we keep a mapping of the package required for modules in
 `node['fb_apache']['module_packages']`. If `manage_packages` is enabled, we will
 install the relevant packages for any modules you enable in
 `node['fb_apache']['modules']`. This is important since it'll happen before we
 attempt to start apache.
+
+### Service
+By default, `fb_apache` will enable and start the Apache service, whatever it
+may be called on your platform. If you'd prefer to do this on your own you can
+set `node['fb_apache']['manage_service']` to `false` and get the name of the
+service on your platform from `FB::Apache.service`. Do not name the resource
+`service[apache]`, however, as it'll conflict with the resource from this
+cookbook (which will be `only_if`'d out).
 
 ### Sites / VirtualHosts
 The `node['fb_apache']['sites']` hash configures virtual hosts. All virtual

--- a/cookbooks/fb_apache/attributes/default.rb
+++ b/cookbooks/fb_apache/attributes/default.rb
@@ -88,6 +88,7 @@ end
 default['fb_apache'] = {
   'sysconfig' => sysconfig,
   'manage_packages' => true,
+  'manage_service' => true,
   'enable_default_site' => true,
   'sites' => {},
   'extra_configs' => {},

--- a/cookbooks/fb_apache/libraries/default.rb
+++ b/cookbooks/fb_apache/libraries/default.rb
@@ -67,5 +67,26 @@ module FB
     def self.get_module_packages(mods, pkgs)
       mods.map { |mod| pkgs[mod] }.uniq.compact
     end
+
+    def self.base_packages(node)
+      node.value_for_platform_family(
+        'rhel' => ['httpd', 'mod_ssl'],
+        'debian' => ['apache2'],
+      )
+    end
+
+    def self.packages(node)
+      base_packages(node) + FB::Apache.get_module_packages(
+        node['fb_apache']['modules'],
+        node['fb_apache']['module_packages'],
+      )
+    end
+
+    def self.service(node)
+      node.value_for_platform_family(
+        'rhel' => 'httpd',
+        'debian' => 'apache2',
+      )
+    end
   end
 end

--- a/cookbooks/fb_apache/recipes/default.rb
+++ b/cookbooks/fb_apache/recipes/default.rb
@@ -99,24 +99,9 @@ sysconfig = value_for_platform_family(
   'debian' => '/etc/default/apache2',
 )
 
-pkgs = value_for_platform_family(
-  'rhel' => ['httpd', 'mod_ssl'],
-  'debian' => ['apache2'],
-)
-
-svc = value_for_platform_family(
-  'rhel' => 'httpd',
-  'debian' => 'apache2',
-)
-
-package pkgs do
+package 'apache packages' do
   only_if { node['fb_apache']['manage_packages'] }
-  package_name lazy {
-    pkgs + FB::Apache.get_module_packages(
-      node['fb_apache']['modules'],
-      node['fb_apache']['module_packages'],
-    )
-  }
+  package_name lazy { FB::Apache.packages(node) }
   action :upgrade
 end
 
@@ -229,6 +214,7 @@ if node['platform_family'] == 'debian'
 end
 
 service 'apache' do
-  service_name svc
+  only_if { node['fb_apache']['manage_service'] }
+  service_name FB::Apache.service(node)
   action [:enable, :start]
 end


### PR DESCRIPTION
It is sometimes desired to have apache configured but not running.
Allow the user to manage the service themselves, just like we do
with packages. Of course, the default remains that Chef manages
the service.

I added a few nicities here:

* For those who were using `manage_packages=false`, you can now easily
  get the list of packages cleanly
* You also easily get the right service name

Signed-off-by: Phil Dibowitz <phil@ipom.com>
