### PR TITLE
 CI fixes: yum repos; disable logind; chef 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         os:
           - centos-stream-8
           - ubuntu-2004
-          - debian-10
+          - debian-11
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -47,7 +47,7 @@ jobs:
         os: ${{ matrix.os }}
       env:
         CHEF_LICENSE: accept-no-persist
-        CHEF_VERSION: 16.18.0
+        CHEF_VERSION: 18.6.14
   shellcheck:
     runs-on: ubuntu-latest
     steps:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,6 +22,9 @@ platforms:
       intermediate_instructions:
         # stub out /etc/fstab for fb_fstab
         - RUN touch /etc/fstab
+        # mirrorlist.centos.org doesn't exist anymore, use baseurl
+        - RUN sed -i=.bak -e 's/^mirrorlist/#mirrorlist/g' -e 's!^#baseurl=http://mirror.centos.org/$contentdir/$stream!baseurl=https://vault.centos.org/$stream!g' /etc/yum.repos.d/*.repo
+        - RUN rm /etc/yum.repos.d/*.bak
         # enable EPEL (for stuff like hddtemp)
         - RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
   - name: ubuntu-18.04
@@ -32,13 +35,9 @@ platforms:
     driver:
       image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
-  - name: debian-9
+  - name: debian-11
     driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-  - name: debian-10
-    driver:
-      image: dokken/debian-10
+      image: dokken/debian-11
       pid_one_command: /bin/systemd
 
 provisioner:

--- a/cookbooks/ci_fixes/recipes/default.rb
+++ b/cookbooks/ci_fixes/recipes/default.rb
@@ -17,3 +17,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+node.default['fb_systemd']['logind']['enable'] = false
+
+# older versions of rsyslog try to call close() on every _possible_ fd
+# as limited by ulimit -n, which can take MINUTES to start. So drop this
+# number for CI: https://github.com/rsyslog/rsyslog/issues/5158
+if node.centos_max_version?(9)
+  node.default['fb_limits']['*']['nofile'] = {
+    'hard' => '1024',
+    'soft' => '1024',
+  }
+end
+
+# postfix hasn't setup it's chroot on rsyslog's first startup and
+# thus it fails in containers on firstboot, so override postfix
+# telling syslog to look at its socket. Why this is an issue only
+# on CentOS, I do not know
+whyrun_safe_ruby_block 'ci fix for postfix/syslog' do
+  only_if { node.centos? }
+  block do
+    node.default['fb_syslog']['rsyslog_additional_sockets'] = []
+  end
+end
+
+# create the certs the default apache looks at
+execute 'create certs' do
+  only_if { node.centos? }
+  command 'openssl req -new -newkey rsa:4096 -x509 -sha256 -days 365 ' +
+    '-nodes -out /etc/pki/tls/certs/localhost.crt ' +
+    '-keyout /etc/pki/tls/private/localhost.key ' +
+    '-subj "/C=US/ST=California/L=Some City/O=Some Org/CN=test"'
+end
+
+# GH Runner's forced apparmor doesn't let binaries write to
+# /run/systemd/notify, so tell the unit not to try
+# why this seems to be issue on CentOS, I do not know
+fb_systemd_override 'syslog-no-systemd' do
+  only_if { node.centos? }
+  unit_name 'rsyslog.service'
+  content({
+            'Service' => {
+              'Type' => 'simple',
+            },
+          })
+end

--- a/cookbooks/fb_syslog/recipes/default.rb
+++ b/cookbooks/fb_syslog/recipes/default.rb
@@ -77,6 +77,6 @@ service service_name do
   action :start
   subscribes :restart, 'package[rsyslog]'
   # within vagrant, sometimes rsyslog fails to restart the first time
-  retries 5
-  retry_delay 5
+  retries 1
+  retry_delay 15
 end


### PR DESCRIPTION
* centos8 mirrors have moved, adjust kitchen setup accordingly.
* logind can't run in containers
* modern chef
* Newer chef requires at least debian 11 for SSL compatability
* rsyslog needs several tweaks to run in containers, added to ci_fixes
* default apache config in centos points to some certs, so make those

This makes everything green _except_ for debian which requires
significant refactors of fb_apt, which can be found in #250, but I 
didn't want production-effecting stuff mixed with CI fixes

Signed-off-by: Phil Dibowitz <phil@ipom.com>

