### PR TITLE
fix tests: remove fb_users from kitchen

### DIFF
--- a/cookbooks/fb_init_sample/recipes/default.rb
+++ b/cookbooks/fb_init_sample/recipes/default.rb
@@ -79,7 +79,9 @@ include_recipe 'fb_limits'
 include_recipe 'fb_hostconf'
 include_recipe 'fb_sysctl'
 # HERE: networking
-include_recipe 'fb_users'
+# until we defined a UID_MAP that works with testing, this can't
+# run in kitchen tests
+# include_recipe 'fb_users'
 if node.centos?
   # We turn this off because the override causes intermittent failures in
   # Travis when rsyslog is restarted


### PR DESCRIPTION
fb_users requires users to fill in UID_MAP, which we haven't done
for the kitchen VMs, so it doesn't make sense to run it in kitchen,
or you just get errors. So remove it for now.

Kitchen tests don't pass, but they get further now and I'm trying to do one -fix-per-PR rather than some huge PR.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
