### PR TITLE
Disable logind in kitchen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         os: ${{ matrix.os }}
       env:
         CHEF_LICENSE: accept-no-persist
-        CHEF_VERSION: 16.18.0
+        CHEF_VERSION: 17.10.163
   shellcheck:
     runs-on: ubuntu-latest
     steps:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,6 +22,9 @@ platforms:
       intermediate_instructions:
         # stub out /etc/fstab for fb_fstab
         - RUN touch /etc/fstab
+        # mirrorlist.centos.org doesn't exist anymore, use baseurl
+        - RUN sed -i=.bak -e 's/^mirrorlist/#mirrorlist/g' -e 's!^#baseurl=http://mirror.centos.org/$contentdir/$stream!baseurl=https://vault.centos.org/$stream!g' /etc/yum.repos.d/*.repo
+        - RUN rm /etc/yum.repos.d/*.bak
         # enable EPEL (for stuff like hddtemp)
         - RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
   - name: ubuntu-18.04

--- a/cookbooks/ci_fixes/recipes/default.rb
+++ b/cookbooks/ci_fixes/recipes/default.rb
@@ -17,3 +17,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+node.default['fb_systemd']['logind']['enable'] = false


### PR DESCRIPTION
It is masked on containers, so it breaks the run.

Signed-off-by: Phil Dibowitz <phil@ipom.com>