### PR TITLE
Fix broken dep between fb_systemd and fb_networkd

### DIFF
--- a/cookbooks/fb_init_sample/recipes/default.rb
+++ b/cookbooks/fb_init_sample/recipes/default.rb
@@ -79,7 +79,9 @@ include_recipe 'fb_limits'
 include_recipe 'fb_hostconf'
 include_recipe 'fb_sysctl'
 # HERE: networking
-include_recipe 'fb_users'
+# until we defined a UID_MAP that works with testing, this can't
+# run in kitchen tests
+# include_recipe 'fb_users'
 if node.centos?
   # We turn this off because the override causes intermittent failures in
   # Travis when rsyslog is restarted

--- a/cookbooks/fb_systemd/recipes/networkd.rb
+++ b/cookbooks/fb_systemd/recipes/networkd.rb
@@ -19,7 +19,7 @@
 #
 
 fb_helpers_gated_template '/etc/systemd/networkd.conf' do
-  only_if { node['fb_systemd']['networkd']['enable'] }
+  only_if { defined?(FB::Networkd) && node['fb_systemd']['networkd']['enable'] }
   allow_changes node.nw_changes_allowed?
   source 'systemd.conf.erb'
   owner node.root_user


### PR DESCRIPTION
Reported by @bwann in #246 and is breaking our tests as well.

Closes #246

Signed-off-by: Phil Dibowitz <phil@ipom.com>
