### PR TITLE
Modernize testing platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1']
+        ruby: ['3.1', '3.3']
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -28,9 +28,11 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - centos-stream-8
-          - ubuntu-2004
-          - debian-11
+          - centos-stream-9
+          - centos-stream-10
+          - ubuntu-2204
+          - ubuntu-2404
+          - debian-12
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -39,7 +41,7 @@ jobs:
       uses: actionshub/chef-install@2.0.4
       with:
         project: chef-workstation
-        version: 20.11.180
+        version: 25.2.1075
     - name: Run Kitchen
       uses: actionshub/test-kitchen@2.1.0
       with:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,18 +6,18 @@ driver:
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 platforms:
-  - name: centos-7
+  - name: centos-stream-9
     driver:
-      image: dokken/centos-7
+      image: dokken/centos-stream-9
       pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         # stub out /etc/fstab for fb_fstab
         - RUN touch /etc/fstab
         # enable EPEL (for stuff like hddtemp)
-        - RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-  - name: centos-stream-8
+        - RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  - name: centos-stream-10
     driver:
-      image: dokken/centos-stream-8
+      image: dokken/centos-stream-10
       pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         # stub out /etc/fstab for fb_fstab
@@ -26,18 +26,18 @@ platforms:
         - RUN sed -i=.bak -e 's/^mirrorlist/#mirrorlist/g' -e 's!^#baseurl=http://mirror.centos.org/$contentdir/$stream!baseurl=https://vault.centos.org/$stream!g' /etc/yum.repos.d/*.repo
         - RUN rm /etc/yum.repos.d/*.bak
         # enable EPEL (for stuff like hddtemp)
-        - RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-  - name: ubuntu-18.04
+        - RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+  - name: ubuntu-24.04
     driver:
-      image: dokken/ubuntu-18.04
+      image: dokken/ubuntu-24.04
       pid_one_command: /bin/systemd
-  - name: ubuntu-20.04
+  - name: ubuntu-22.04
     driver:
-      image: dokken/ubuntu-20.04
+      image: dokken/ubuntu-22.04
       pid_one_command: /bin/systemd
-  - name: debian-11
+  - name: debian-12
     driver:
-      image: dokken/debian-11
+      image: dokken/debian-12
       pid_one_command: /bin/systemd
 
 provisioner:

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'chef', '~> 16'
+gem 'chef', '~> 18'
 gem 'cookstyle', '= 7.32.1'
 gem 'rspec', '= 3.11'
 gem 'rubocop', '= 1.25.1'

--- a/cookbooks/ci_fixes/attributes/default.rb
+++ b/cookbooks/ci_fixes/attributes/default.rb
@@ -15,24 +15,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-# monkeypatch for https://github.com/chef/ohai/pull/1476
-if FB::Version.new(Chef::VERSION) < FB::Version.new('16.2.2')
-  Chef::Log.debug('ci_fixes: applying virtualization monkeypatch')
-
-  if File.exist?('/proc/self/cgroup')
-    cgroup_content = File.read('/proc/self/cgroup')
-    if cgroup_content =~ %r{^\d+:[^:]*:/(lxc|docker)/.+$} ||
-      cgroup_content =~ %r{^\d+:[^:]*:/[^/]+/(lxc|docker)-?.+$}
-      Chef::Log.info(
-        'Plugin Virtualization Monkeypatch: /proc/self/cgroup indicates ' +
-        "#{$1} container. Detecting as #{$1} guest",
-      )
-      node.automatic['virtualization']['system'] = $1 # rubocop:disable Chef/Meta/UseNodeDefault
-      node.automatic['virtualization']['role'] = 'guest' # rubocop:disable Chef/Meta/UseNodeDefault
-      node.automatic['virtualization']['systems'][$1.to_s] = 'guest' # rubocop:disable Chef/Meta/UseNodeDefault
-    end
-  end
-else
-  Chef::Log.warn('ci_fixes: clean up the virtualization monkeypatch!')
-end

--- a/cookbooks/fb_init_sample/recipes/default.rb
+++ b/cookbooks/fb_init_sample/recipes/default.rb
@@ -128,12 +128,18 @@ if node.firstboot_tier?
 end
 
 unless node.centos6?
-  include_recipe 'fb_apcupsd'
+  # not packaged in C10 and above
+  if node.centos_max_version?(9)
+    include_recipe 'fb_apcupsd'
+  end
   # Turn off dnsmasq as it doesn't play well with travis
   node.default['fb_dnsmasq']['enable'] = false
   include_recipe 'fb_dnsmasq'
 end
-include_recipe 'fb_collectd'
+# not packaged in C10 and above
+unless node.centos10?
+  include_recipe 'fb_collectd'
+end
 include_recipe 'fb_rsync::server'
 if node.centos?
   include_recipe 'fb_sysstat'

--- a/cookbooks/test_services/recipes/default.rb
+++ b/cookbooks/test_services/recipes/default.rb
@@ -27,7 +27,11 @@ end
 include_recipe 'fb_apache'
 if node.debian? || (node.ubuntu? && !node.ubuntu16?)
   include_recipe 'fb_apt_cacher'
-  include_recipe 'fb_smokeping'
+  # ubuntu post-18 doesn't package echoping which the config
+  # in fb_smokeping depends on, so don't run it, for now
+  if node.ubuntu18? || node.ubuntu20?
+    include_recipe 'fb_smokeping'
+  end
 end
 
 # Currently fb_reprepro is broken


### PR DESCRIPTION
Chef 18, Workstaiton 25, Centos 9&10, Debian 12, Ubuntu 22+

This won't work until other PRs are merged, but getting it ready.
