### PR TITLE
fb_apache: minor fixes

### DIFF
--- a/cookbooks/fb_apache/attributes/default.rb
+++ b/cookbooks/fb_apache/attributes/default.rb
@@ -152,6 +152,7 @@ default['fb_apache'] = {
     'proxy_fcgi' => 'mod_proxy_fcgi.so',
     'proxy_ftp' => 'mod_proxy_ftp.so',
     'proxy_http' => 'mod_proxy_http.so',
+    'proxy_http2' => 'mod_proxy_http2.so',
     'proxy_scgi' => 'mod_proxy_scgi.so',
     'reqtimeout' => 'mod_reqtimeout.so',
     'rewrite' => 'mod_rewrite.so',

--- a/cookbooks/fb_apache/resources/verify_configs.rb
+++ b/cookbooks/fb_apache/resources/verify_configs.rb
@@ -89,14 +89,19 @@ action :verify do
       mode '0644'
     end.run_action(:create)
 
-    build_resource(:template,
-                   "#{tdir}/#{new_resource.confdir}/status.conf") do
-      source 'status.erb'
-      owner 'root'
-      group 'root'
-      mode '0644'
-      variables(:location => '/server-status')
-    end.run_action(:create)
+    if node['fb_apache']['enable_public_status']
+      build_resource(:template,
+                     "#{tdir}/#{new_resource.confdir}/status.conf") do
+        source 'status.erb'
+        owner 'root'
+        group 'root'
+        mode '0644'
+        variables(:location => '/server-status')
+      end.run_action(:create)
+    else
+      build_resource(:file, "#{tdir}/#{new_resource.confdir}/status.conf").
+        run_action(:delete)
+    end
 
     verify_cmd = value_for_platform_family(
       'rhel' => "httpd -t -d #{tdir}",


### PR DESCRIPTION
* Recenty we added the knob to control `status.conf`, except that
  we didn't implement it in the verify_configs, so it was (1) testing
  the wrong thing and (2) making why-run lie
* Add module-mapping for mod_proxy_http2

Signed-off-by: Phil Dibowitz <phil@ipom.com>
