### PR TITLE
fb_nsswitch: include gshadow in defaults

### DIFF
--- a/cookbooks/fb_nsswitch/attributes/default.rb
+++ b/cookbooks/fb_nsswitch/attributes/default.rb
@@ -23,6 +23,7 @@ databases = {}
   automount
   ethers
   group
+  gshadow
   hosts
   initgroups
   netgroup


### PR DESCRIPTION
This is in the reasonable defaults on most OSes.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
