### PR TITLE
fb_systemd: don't enable resolved when not enabled

### DIFF
--- a/cookbooks/fb_systemd/recipes/default_packages.rb
+++ b/cookbooks/fb_systemd/recipes/default_packages.rb
@@ -44,7 +44,6 @@ when 'debian'
     systemd_packages += %w{
       libnss-myhostname
       libnss-mymachines
-      libnss-resolve
       systemd-container
       systemd-coredump
     }
@@ -77,6 +76,7 @@ package 'systemd packages' do
       end
       if node['fb_systemd']['resolved']['enable'] && has_split_rpms
         systemd_packages << 'systemd-resolved'
+        systemd_packages << 'libnss-resolve'
       end
       if node['fb_systemd']['nspawn']['enable'] && has_split_rpms
         systemd_packages << 'systemd-container'


### PR DESCRIPTION
`libnss-resolve` pulls in `systemd-resolved`, which overwrites
`/etc/resolv.conf` on installation, but if you haven't enabled
systemd-resolved, then it's down and everything breaks.

So don't install it unless we're also planning to install resolved.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
