### PR TITLE
Fix `run_cookstyle`

### DIFF
--- a/scripts/run_cookstyle
+++ b/scripts/run_cookstyle
@@ -39,7 +39,10 @@ EOF
 }
 
 CONFIG='.cookstyle_combined.yml'
-RULES_DIR="$(pwd)/cookstyle/" # `cookstyle -r FOO` expects FOO to be absolute
+ME=$(realpath "$0")
+MY_DIR=$(dirname "$ME")
+# `cookstyle -r FOO` expects FOO to be absolute
+RULES_DIR="${MY_DIR}/../cookstyle/"
 AUTOCORRECT=0
 COMPAT_MODE=1
 


### PR DESCRIPTION
Recent changes from #296 broke the ability to run `run_cookstyle` from
directories other than the root directory.

That, in-turn breaks the ability to run it in other repos, and I have
several repos that just call `run_cookstyle` from the checkout of this
repo to keep style in-sync.

This fixes both of those cases.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
