### PR TITLE
fb_networkmanager: fix missing default

### DIFF
--- a/cookbooks/fb_networkmanager/resources/system_connections.rb
+++ b/cookbooks/fb_networkmanager/resources/system_connections.rb
@@ -29,6 +29,10 @@ action :manage do
     files = determine_files(name, config)
 
     current, new_config = generate_config_hashes(files['from'], config)
+    # Give it the friendly name the user wanted
+    unless new_config['id']
+      new_config['connection']['id'] = name
+    end
 
     template files['config'] do
       # we don't rely just on the idempotency of the template because


### PR DESCRIPTION
This got lost somewhere in the review process updates.

We name the files `fb_networkmanager_*` so that we can make sure we
only mess with things we own, but that's not what the user expects
the network to show up, so we must set `connection.id` to the name of
the network (unless the user has chosen something else).

Further, without doing this, NetworkManager will create a separate
connection for the network if this one has not yet been activated but
the network is seen.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
