### PR TITLE
Fix ChefUtils scoping

### DIFF
--- a/cookbooks/fb_dhcprelay/attributes/default.rb
+++ b/cookbooks/fb_dhcprelay/attributes/default.rb
@@ -22,7 +22,7 @@ sysconfig = {
   'servers' => [],
   'options' => [],
 }
-if ::ChefUtils.debian?
+if node.debian_family?
   sysconfig['interfaces'] = []
 end
 

--- a/cookbooks/test_services/recipes/default.rb
+++ b/cookbooks/test_services/recipes/default.rb
@@ -50,7 +50,7 @@ if node.debian? || (node.ubuntu? && !node.ubuntu16?)
   # if running behind a NAT, so don't run while using VirtualBox
   # https://github.com/openspace42/aenigma/issues/48
   # https://github.com/test-kitchen/test-kitchen/issues/458
-  unless ::ChefUtils.kitchen? || node['virtualization']['system'] == 'vbox'
+  unless kitchen? || node['virtualization']['system'] == 'vbox'
     node.default['fb_ejabberd']['config']['hosts'] << 'sample.com'
     include_recipe 'fb_ejabberd'
   end


### PR DESCRIPTION
In an attempt to fix internal scoping conflicts, I scoped calls to
ChefUtils helpers, but you can't do that because they need to be mixed
in the the current DSL.

This drops the two scopes that were left. For `kitchen?` there's no
duplicate, so we're fine. For `debian?`, I moved to
`node.debian_family?`

Signed-off-by: Phil Dibowitz <phil@ipom.com>
