### PR TITLE
fb_spamassassin: Fix timer jobs

### DIFF
--- a/cookbooks/fb_spamassassin/recipes/default.rb
+++ b/cookbooks/fb_spamassassin/recipes/default.rb
@@ -123,13 +123,13 @@ end
 systemd_unit 'enable spam assassin update job' do
   only_if { node['fb_spamassassin']['enable_update_job'] }
   unit_name "#{update_job}.timer"
-  action [:enable]
+  action [:enable, :start]
 end
 
 systemd_unit 'disable spam assassin update job' do
   not_if { node['fb_spamassassin']['enable_update_job'] }
   unit_name "#{update_job}.timer"
-  action [:disable]
+  action [:stop, :disable]
 end
 
 service 'spamd' do


### PR DESCRIPTION
Somehow I had gotten it in my head when I wrote a bunch of these
cookbooks that timer jobs needed to `:enable`'d but `:start` would
run the actual job. That is, of course, not true, the underlying
_service_ can be started to do an immediate run.

As a result the update jobs never ran, when expected. This fixes that.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
