### PR TITLE
fb_helpers cleanup

### DIFF
--- a/cookbooks/fb_helpers/README.md
+++ b/cookbooks/fb_helpers/README.md
@@ -39,23 +39,26 @@ your node.
 * `node.centos?`
     Is CentOS
 
+* `node.centos_version?(v)`
+    Is this CentOS version v
+
 * `node.centos5?`
-    Is CentOS Linux 5
+    Is CentOS Linux 5 - Deprecated: use `node.centos_version?`
 
 * `node.centos6?`
-    Is CentOS Linux 6
+    Is CentOS Linux 6 - Deprecated: use `node.centos_version?`
 
 * `node.centos7?`
-    Is CentOS Linux 7
+    Is CentOS Linux 7 - Deprecated: use `node.centos_version?`
 
 * `node.centos8?`
-    Is CentOS Linux 8 or CentOS Stream 8
+    Is CentOS Linux 8 or CentOS Stream 8 - Deprecated: use `node.centos_version?`
 
 * `node.centos9?`
-    Is CentOS Stream 9
+    Is CentOS Stream 9 - Deprecated: use `node.centos_version?`
 
 * `node.centos10?`
-    Is CentOS Stream 10
+    Is CentOS Stream 10 - Deprecated: use `node.centos_version?`
 
 * `node.centos_max_version?(v, full=false)`
     Is RHEL-compatible with a maximum version number of v
@@ -66,49 +69,52 @@ your node.
     See os_min_version? for details
 
 * `node.fedora?`
-    Is Fedora
+    Is Fedora. Needs to be Deprecated in favor of ChefUtils fedora?
+
+* `node.fedora_version?(v)`
+   Is this Fedora version v (e.g. `node.fedora_version?(41)`)
 
 * `node.fedora27?`
-    Is Fedora 27
+    Is Fedora 27 - Deprecated, use `node.fedora_version?`
 
 * `node.fedora28?`
-    Is Fedora 28
+    Is Fedora 28 - Deprecated use `node.fedora_version?`
 
 * `node.fedora29?`
-    Is Fedora 29
+    Is Fedora 29 - Deprecated use `node.fedora_version?`
 
 * `node.fedora30?`
-    Is Fedora 30
+    Is Fedora 30 - Deprecated use `node.fedora_version?`
 
 * `node.fedora31?`
-    Is Fedora 31
+    Is Fedora 31 - Deprecated use `node.fedora_version?`
 
 * `node.fedora32?`
-    Is Fedora 32
+    Is Fedora 32 - Deprecated use `node.fedora_version?`
 
 * `node.fedora33?`
-    Is Fedora 33
+    Is Fedora 33 - Deprecated use `node.fedora_version?`
 
 * `node.fedora34?`
-    Is Fedora 34
+    Is Fedora 34 - Deprecated use `node.fedora_version?`
 
 * `node.fedora35?`
-    Is Fedora 35
+    Is Fedora 35 - Deprecated use `node.fedora_version?`
 
 * `node.fedora36?`
-    Is Fedora 36
+    Is Fedora 36 - Deprecated use `node.fedora_version?`
 
 * `node.fedora37?`
-    Is Fedora 37
+    Is Fedora 37 - Deprecated use `node.fedora_version?`
 
 * `node.fedora38?`
-    Is Fedora 38
+    Is Fedora 38 - Deprecated use `node.fedora_version?`
 
 * `node.fedora39?`
-    Is Fedora 39
+    Is Fedora 39 - Deprecated use `node.fedora_version?`
 
 * `node.fedora40?`
-    Is Fedora 40
+    Is Fedora 40 - Deprecated use `node.fedora_version?`
 
 * `node.fedora_max_version?(v, full=false)`
     Is RHEL-compatible with a maximum version number of v
@@ -124,20 +130,23 @@ your node.
 * `node.redhat?`
     Is Redhat Enterprise Linux
 
+* `node.redhat_version?`
+    Is Redhat Enterprise Linux version v
+
 * `node.redhat6?`
-    Is Redhat Enterprise Linux 6
+    Is Redhat Enterprise Linux 6 - Deprecated use `node.redhat_version?`
 
 * `node.redhat7?`
-    Is Redhat Enterprise Linux 7
+    Is Redhat Enterprise Linux 7 - Deprecated use `node.redhat_version?`
 
 * `node.redhat8?`
-    Is Redhat Enterprise Linux 8
+    Is Redhat Enterprise Linux 8 - Deprecated use `node.redhat_version?`
 
 * `node.redhat9?`
-    Is Redhat Enterprise Linux 9
+    Is Redhat Enterprise Linux 9 - Deprecated use `node.redhat_version?`
 
 * `node.redhat10?`
-    Is Redhat Enterprise Linux 10
+    Is Redhat Enterprise Linux 10 - Deprecated use `node.redhat_version?`
 
 * `node.rhel_max_version?(v, full=false)`
     Is Redhat Enterprise Linux with a maximum major version number of v
@@ -148,84 +157,95 @@ your node.
     See os_min_version? for details.
 
 * `node.rhel?`
-    Is Redhat Enterprise Linux
+    Is Redhat Enterprise Linux-compatible (eg CentOS, Oracle Linux, Rocky Linux)
+
+* `node.rhel_version?`
+    Is Redhat Enterprise Linux Family version v
 
 * `node.rhel7?`
-    Is Redhat Enterprise Linux 7
+    Is Redhat Enterprise Linux 7 - Deprecated use `node.rhel_version?`
 
 * `node.rhel8?`
-    Is Redhat Enterprise Linux 8
+    Is Redhat Enterprise Linux 8 - Deprecated use `node.rhel_version?`
 
 * `node.rhel8_8?`
-    Is Redhat Enterprise Linux 8.8
+    Is Redhat Enterprise Linux 8.8 - Deprecated use `node.rhel_version?`
 
 * `node.rhel9?`
-    Is Redhat Enterprise Linux 9
+    Is Redhat Enterprise Linux 9 - Deprecated use `node.rhel_version?`
 
 * `node.rhel10?`
-    Is Redhat Enterprise Linux 10
+    Is Redhat Enterprise Linux 10 - Deprecated use `node.rhel_version?`
 
 * `node.oracle?`
     Is Oracle Enterprise Linux
 
+* `node.oracle_version?`
+    Is Oracle Enterprise Linux version v
+
 * `node.oracle5?`
-    Is Oracle Enterprise Linux 5
+    Is Oracle Enterprise Linux 5 - Deprecated use `node.oracle_version?`
 
 * `node.oracle6?`
-    Is Oracle Enterprise Linux 6
+    Is Oracle Enterprise Linux 6 - Deprecated use `node.oracle_version?`
 
 * `node.oracle7?`
-    Is Oracle Enterprise Linux 7
+    Is Oracle Enterprise Linux 7 - Deprecated use `node.oracle_version?`
 
 * `node.oracle8?`
-    Is Oracle Enterprise Linux 8
+    Is Oracle Enterprise Linux 8 - Deprecated use `node.oracle_version?`
 
 * `node.rhel_family?`
-    Is Redhat Enterprise Linux-compatible (eg CentOS, Oracle Linux, Rocky Linux)
+    Backwards-compat alias for `node.rhel?`
 
 * `node.el_max_version?(v, full=false)`
-    Is RHEL-compatible with a maximum version number of v
-    See os_max_version? for details.
+    Alias for rhel_max_version?
 
 * `node.el_min_version?(v, full=false)`
-    Is RHEL-compatible with a minimum version number of v
-    See os_min_version? for details.
+    Alias for rhel_min_version?
 
 * `node.debian?`
     Is Debian
 
-* `node.ubuntu?`
+* `node.ubuntu?` - need to be removed in favor of ChefUtils `ubuntu_platform?`
     Is Ubuntu
 
+* `node.ubuntu_version?(v)`
+    True if ubuntu and this specific version. If you pass in an integer, or
+    string-holding-an-integer (e.g. `22`), then it will be true for all 22
+    versions (22.04, 22.10, etc.). If you pass in a float, or
+    string-holding-a-float (e.g. `22.04`), then it will return true only for
+    that specific version.
+
 * `node.ubuntu12?`
-    Is Ubuntu14
+    Is Ubuntu12 - Deprecated, use `node.ubuntu_version?`
 
 * `node.ubuntu14?`
-    Is Ubuntu14
+    Is Ubuntu14 - Deprecated, use `node.ubuntu_version?`
 
 * `node.ubuntu15?`
-    Is Ubuntu15
+    Is Ubuntu15 - Deprecated, use `node.ubuntu_version?`
 
 * `node.ubuntu16?`
-    Is Ubuntu16
+    Is Ubuntu16 - Deprecated, use `node.ubuntu_version?`
 
 * `node.ubuntu1610?`
-    Is Ubuntu16.10
+    Is Ubuntu16.10 - Deprecated, use `node.ubuntu_version?`
 
 * `node.ubuntu17?`
-    Is Ubuntu17
+    Is Ubuntu17 - Deprecated, use `node.ubuntu_version?`
 
 * `node.ubuntu1704?`
-    Is Ubuntu17.04
+    Is Ubuntu17.04 - Deprecated, use `node.ubuntu_version?`
 
 * `node.ubuntu18?`
-    Is Ubuntu18
+    Is Ubuntu18 - Deprecated, use `node.ubuntu_version?`
 
 * `node.ubuntu1804?`
-    Is Ubuntu18.04
+    Is Ubuntu18.04 - Deprecated, use `node.ubuntu_version?`
 
 * `node.ubuntu20?`
-    Is Ubuntu20
+    Is Ubuntu20 - Deprecated, use `node.ubuntu_version?`
 
 * `node.linux?`
     Is Linux
@@ -233,14 +253,17 @@ your node.
 * `node.macos?`
     Is macOS (any version)
 
+* `node.macos_version?(v)`
+    Is macOS version v
+
 * `node.macos10?`
-    Is macOS Catalina (macOS 10)
+    Is macOS Catalina (macOS 10) - Deprecated use `node.macos_version?`
 
 * `node.macos11?`
-    Is macOS Big Sur (macOS 11)
+    Is macOS Big Sur (macOS 11) - Deprecated use `node.macos_version?`
 
 * `node.macos12?`
-    Is macOS Monterey (macOS 12)
+    Is macOS Monterey (macOS 12) - Deprecated use `node.macos_version?`
 
 * `node.windows?`
     Is Windows
@@ -267,16 +290,23 @@ your node.
     Is Windows 2019
 
 * `node.aristaeos?`
-    Is network switch running Arista EOS
+    Is network switch running Arista EOS.
+
+* `node.aristaeos_v_plus?(v)`
+    Is network switch running Arista EOS and OS version v or newer.
+    `v` must be a string.
 
 * `node.aristaeos_4_28_or_newer?`
     Is network switch running Arista EOS and OS version is 4.28 or newer
+    Deprecated - use `node.aristaeos_v_plus?`
 
 * `node.aristaeos_4_30_or_newer?`
     Is network switch running Arista EOS and OS version is 4.30 or newer
+    Deprecated - use `node.aristaeos_v_plus?`
 
 * `node.aristaeos_4_32_or_newer?`
     Is network switch running Arista EOS and OS version is 4.32 or newer
+    Deprecated - use `node.aristaeos_v_plus?`
 
 * `node.embedded?`
     Is embedded Linux, implies 'node.aristaeos?'. These devices likely have

--- a/cookbooks/fb_helpers/libraries/node_methods.rb
+++ b/cookbooks/fb_helpers/libraries/node_methods.rb
@@ -31,10 +31,6 @@ class Chef
       self['platform_version'].split('.')[0]
     end
 
-    def rhel_family?
-      self['platform_family'] == 'rhel'
-    end
-
     def _canonical_version(version)
       @canonical_version ||= {}
 
@@ -48,7 +44,8 @@ class Chef
           when FB::Version
             version
           else
-            fail 'fb_helpers: Version comparison can only be performed with strings and numbers'
+            fail 'fb_helpers: Version comparison can only be performed ' +
+              'with strings and numbers'
           end
       end
     end
@@ -73,62 +70,85 @@ class Chef
       end
     end
 
-    # Is this a RHEL-compatible OS with a minimum major version number of `version`
+    # Is this a RHEL-compatible OS with a minimum major version number of
+    # `version`
     def el_min_version?(version, full = false)
       self.rhel_family? && self.os_min_version?(version, full)
     end
 
-    # Is this a RHEL-compatible OS with a maximum major version number of `version`
+    # Is this a RHEL-compatible OS with a maximum major version number of
+    # `version`
     def el_max_version?(version, full = false)
       self.rhel_family? && self.os_max_version?(version, full)
     end
 
-    def rhel_family7?
-      self.rhel_family? && self['platform_version'].start_with?('7')
-    end
-
-    def rhel_family8?
-      self.rhel_family? && self['platform_version'].start_with?('8')
-    end
-
-    def rhel_family9?
-      self.rhel_family? && self['platform_version'].start_with?('9')
-    end
-
-    def rhel_family10?
-      self.rhel_family? && self['platform_version'].start_with?('10')
-    end
-
     def rhel?
-      self.rhel_family?
+      self['platform_family'] == 'rhel'
     end
 
+    # DEPRECATED: use rhel?
+    def rhel_family?
+      self.rhel?
+    end
+
+    def rhel_version?(v)
+      self.rhel? && self._platform_version_helper?(v)
+    end
+
+    # alias for the el_ variant
     def rhel_min_version?(version, full = false)
-      self.rhel? && self.el_min_version?(version, full)
+      self.el_min_version?(version, full)
     end
 
+    # alias for the el_ variant
     def rhel_max_version?(version, full = false)
-      self.rhel? && self.el_max_version?(version, full)
+      self.el_max_version?(version, full)
     end
 
+    # DEPRECATED: use rhel_version?
+    def rhel_family7?
+      self.rhel_version?(7)
+    end
+
+    # DEPRECATED: use rhel_version?
+    def rhel_family8?
+      self.rhel_version?(8)
+    end
+
+    # DEPRECATED: use rhel_version?
+    def rhel_family9?
+      self.rhel_version?(9)
+    end
+
+    # DEPRECATED: use rhel_version?
     def rhel7?
-      self.rhel? && self['platform_version'].start_with?('7')
+      self.rhel_version?(7)
     end
 
+    # DEPRECATED: use rhel_version?
     def rhel8?
-      self.rhel? && self['platform_version'].start_with?('8')
+      self.rhel_version?(8)
     end
 
+    # DEPRECATED: use rhel_version?
     def rhel8_8?
-      self.rhel? && self['platform_version'].start_with?('8.8')
+      self.rhel_version?('8.8')
     end
 
+    # DEPRECATED: use rhel_version?
     def rhel9?
-      self.rhel? && self['platform_version'].start_with?('9')
+      self.rhel_version?(9)
     end
 
+    # DEPRECATED: use rhel_version?
     def rhel10?
-      self.rhel? && self['platform_version'].start_with?('10')
+      self.rhel_version?(10)
+    end
+
+    # DO NOT ADD anymore rhelXX? methods, use rhel_version?
+
+    def centos?
+      self['platform'] == 'centos'
     end
 
     def centos_min_version?(version, full = false)
@@ -139,33 +159,41 @@ class Chef
       self.centos? && self.os_max_version?(version, full)
     end
 
-    def centos?
-      self['platform'] == 'centos'
+    def centos_version?(v)
+      self.centos? && self._platform_version_helper?(v)
     end
 
-    def centos10?
-      self.centos? && self['platform_version'].start_with?('10')
-    end
-
-    def centos9?
-      self.centos? && self['platform_version'].start_with?('9')
-    end
-
-    def centos8?
-      self.centos? && self['platform_version'].start_with?('8')
-    end
-
-    def centos7?
-      self.centos? && self['platform_version'].start_with?('7')
-    end
-
-    def centos6?
-      self.centos? && self['platform_version'].start_with?('6')
-    end
-
+    # DEPRECATED: use centos_version?
     def centos5?
-      self.centos? && self['platform_version'].start_with?('5')
+      self.centos_version?(5)
     end
+
+    # DEPRECATED: use centos_version?
+    def centos6?
+      self.centos_version?(6)
+    end
+
+    # DEPRECATED: use centos_version?
+    def centos7?
+      self.centos_version?(7)
+    end
+
+    # DEPRECATED: use centos_version?
+    def centos8?
+      self.centos_version?(8)
+    end
+
+    # DEPRECATED: use centos_version?
+    def centos9?
+      self.centos_version?(9)
+    end
+
+    # DEPRECATED: use centos_version?
+    def centos10?
+      self.centos_version?(10)
+    end
+
+    # DO NOT ADD anymore centosXX? methods, use rhel_version?
 
     def rocky?
       self['platform'] == 'rocky'
@@ -191,25 +219,36 @@ class Chef
       self.redhat? && self.os_min_version?(version, full)
     end
 
+    def redhat_version?(v)
+      self.redhat? && self._platform_version_helper?(v)
+    end
+
+    # DEPRECATED: use redhat_version?
     def redhat6?
-      self.redhat? && self['platform_version'].start_with?('6')
+      self.redhat_version?(6)
     end
 
+    # DEPRECATED: use redhat_version?
     def redhat7?
-      self.redhat? && self['platform_version'].start_with?('7')
+      self.redhat_version?(7)
     end
 
+    # DEPRECATED: use redhat_version?
     def redhat8?
-      self.redhat? && self['platform_version'].start_with?('8')
+      self.redhat_version?(8)
     end
 
+    # DEPRECATED: use redhat_version?
     def redhat9?
-      self.redhat? && self['platform_version'].start_with?('9')
+      self.redhat_version?(9)
     end
 
+    # DEPRECATED: use redhat_version?
     def redhat10?
-      self.redhat? && self['platform_version'].start_with?('10')
+      self.redhat_version?(10)
     end
+
+    # DO NOT ADD anymore redhatXX? methods, use redhat_version?
 
     def oracle?
       self['platform'] == 'oracle'
@@ -223,29 +262,41 @@ class Chef
       self.oracle? && self.os_min_version?(version, full)
     end
 
-    def oracle10?
-      self.oracle? && self['platform_version'].start_with?('10')
+    def oracle_version?(v)
+      self.oracle? && self._platform_version_helper?(v)
     end
 
-    def oracle9?
-      self.oracle? && self['platform_version'].start_with?('9')
-    end
-
-    def oracle8?
-      self.oracle? && self['platform_version'].start_with?('8')
-    end
-
-    def oracle7?
-      self.oracle? && self['platform_version'].start_with?('7')
-    end
-
-    def oracle6?
-      self.oracle? && self['platform_version'].start_with?('6')
-    end
-
+    # DEPRECATED: use oracle_version?
     def oracle5?
-      self.oracle? && self['platform_version'].start_with?('5')
+      self.oracle_version?(5)
     end
+
+    # DEPRECATED: use oracle_version?
+    def oracle6?
+      self.oracle_version?(6)
+    end
+
+    # DEPRECATED: use oracle_version?
+    def oracle7?
+      self.oracle_version?(7)
+    end
+
+    # DEPRECATED: use oracle_version?
+    def oracle8?
+      self.oracle_version?(8)
+    end
+
+    # DEPRECATED: use oracle_version?
+    def oracle9?
+      self.oracle_version?(9)
+    end
+
+    # DEPRECATED: use oracle_version?
+    def oracle10?
+      self.oracle_version?(10)
+    end
+
+    # DO NOT ADD anymore redhatXX? methods, use _version?
 
     def fedora_family?
       self['platform_family'] == 'fedora'
@@ -255,61 +306,81 @@ class Chef
       self['platform'] == 'fedora'
     end
 
+    def fedora_version?(v)
+      self.fedora? && self._platform_version_helper?(v)
+    end
+
+    # DEPRECATED: Use fedora_version?
     def fedora27?
-      self.fedora? && self['platform_version'] == '27'
+      self.fedora_version?(27)
     end
 
+    # DEPRECATED: Use fedora_version?
     def fedora28?
-      self.fedora? && self['platform_version'] == '28'
+      self.fedora_version?(28)
     end
 
+    # DEPRECATED: Use fedora_version?
     def fedora29?
-      self.fedora? && self['platform_version'] == '29'
+      self.fedora_version?(29)
     end
 
+    # DEPRECATED: Use fedora_version?
     def fedora30?
-      self.fedora? && self['platform_version'] == '30'
+      self.fedora_version?(30)
     end
 
+    # DEPRECATED: Use fedora_version?
     def fedora31?
-      self.fedora? && self['platform_version'] == '31'
+      self.fedora_version?(31)
     end
 
+    # DEPRECATED: Use fedora_version?
     def fedora32?
-      self.fedora? && self['platform_version'] == '32'
+      self.fedora_version?(32)
     end
 
+    # DEPRECATED: Use fedora_version?
     def fedora33?
-      self.fedora? && self['platform_version'] == '33'
+      self.fedora_version?(33)
     end
 
+    # DEPRECATED: Use fedora_version?
     def fedora34?
-      self.fedora? && self['platform_version'] == '34'
+      self.fedora_version?(34)
     end
 
+    # DEPRECATED: Use fedora_version?
     def fedora35?
-      self.fedora? && self['platform_version'] == '35'
+      self.fedora_version?(35)
     end
 
+    # DEPRECATED: Use fedora_version?
     def fedora36?
-      self.fedora? && self['platform_version'] == '36'
+      self.fedora_version?(36)
     end
 
+    # DEPRECATED: Use fedora_version?
     def fedora37?
-      self.fedora? && self['platform_version'] == '37'
+      self.fedora_version?(37)
     end
 
+    # DEPRECATED: Use fedora_version?
     def fedora38?
-      self.fedora? && self['platform_version'] == '38'
+      self.fedora_version?(38)
     end
 
+    # DEPRECATED: Use fedora_version?
     def fedora39?
-      self.fedora? && self['platform_version'] == '39'
+      self.fedora_version?(39)
     end
 
+    # DEPRECATED: Use fedora_version?
     def fedora40?
-      self.fedora? && self['platform_version'] == '40'
+      self.fedora_version?(40)
     end
+
+    # DO NOT ADD MORE fedoraXX? methods - use `fedora_version?`
 
     def fedora_max_version?(version, full = false)
       self.fedora? && self.os_max_version?(version, full)
@@ -351,6 +422,36 @@ class Chef
       self['platform'] == 'ubuntu'
     end
 
+    # If it includes a dot, compares version exactly.
+    # If it does not contain a dot, ensures the value
+    # is either the same, or starts with that verison and a dot
+    def _platform_version_helper?(v)
+      case v
+      when Integer, String
+        v = v.to_s
+        # If they're exactly equal as strings, that's just true always
+        return true if self['platform_version'] == v
+
+        if v.include?('.')
+          # If there's a dot, expect exact match, and if we're here
+          # that's not true, so return false
+          false
+        else
+          # If there's no dot and it's not exact match,
+          # then check it matches the major version
+          self['platform_version'].start_with?("#{v}.")
+        end
+      when Float
+        # this is needed so that 24.4 matches 24.04 - converts
+        # it all into FB::Version and does the right thing
+        self._self_version == v.to_s
+      end
+    end
+
+    def ubuntu_version?(v)
+      ubuntu_platform? && self._platform_version_helper?(v)
+    end
+
     def ubuntu_max_version?(version, full = false)
       self.ubuntu? && self.os_max_version?(version, full)
     end
@@ -359,45 +460,57 @@ class Chef
       self.ubuntu? && self.os_min_version?(version, full)
     end
 
+    # DEPRECATED: Use ubuntu_version?
     def ubuntu12?
-      ubuntu? && self['platform_version'].start_with?('12')
+      self.ubuntu_version?(12)
     end
 
+    # DEPRECATED: Use ubuntu_version?
     def ubuntu14?
-      ubuntu? && self['platform_version'].start_with?('14.')
+      self.ubuntu_version?(14)
     end
 
+    # DEPRECATED: Use ubuntu_version?
     def ubuntu15?
-      ubuntu? && self['platform_version'].start_with?('15.')
+      self.ubuntu_version?(15)
     end
 
+    # DEPRECATED: Use ubuntu_version?
     def ubuntu16?
-      ubuntu? && self['platform_version'].start_with?('16.')
+      self.ubuntu_version?(16)
     end
 
+    # DEPRECATED: Use ubuntu_version?
     def ubuntu1610?
-      ubuntu? && self['platform_version'] == '16.10'
+      self.ubuntu_version?(16.10)
     end
 
+    # DEPRECATED: Use ubuntu_version?
     def ubuntu17?
-      ubuntu? && self['platform_version'].start_with?('17')
+      self.ubuntu_version?(17)
     end
 
+    # DEPRECATED: Use ubuntu_version?
     def ubuntu1704?
-      ubuntu? && self['platform_version'] == '17.04'
+      self.ubuntu_version?(17.04)
     end
 
+    # DEPRECATED: Use ubuntu_version?
     def ubuntu18?
-      ubuntu? && self['platform_version'].start_with?('18.')
+      self.ubuntu_version?(18)
     end
 
+    # DEPRECATED: Use ubuntu_version?
     def ubuntu1804?
-      ubuntu? && self['platform_version'] == '18.04'
+      self.ubuntu_version?(18.04)
     end
 
+    # DEPRECATED: Use ubuntu_version?
     def ubuntu20?
-      ubuntu? && self['platform_version'].start_with?('20.')
+      self.ubuntu_version?(20)
     end
+
+    # DO NOT ADD ADDITIONAL ubuntuXX? methods, use ubuntu_version?
 
     def linuxmint?
       self['platform'] == 'linuxmint'
@@ -417,33 +530,48 @@ class Chef
 
     alias macosx? macos?
 
+    def macos_version?(v)
+      macos? && self._platform_version_helper?(v)
+    end
+
+    # DEPRECATED: Use macos_version?
     def macos10?
-      macos? && self['platform_version'].start_with?('10.')
+      self.macos_version?(10)
     end
 
+    # DEPRECATED: Use macos_version?
     def macos11?
-      macos? && self['platform_version'].start_with?('11.')
+      self.macos_version?(11)
     end
 
+    # DEPRECATED: Use macos_version?
     def macos12?
-      macos? && self['platform_version'].start_with?('12.')
+      self.macos_version?(12)
     end
 
+    # DEPRECATED: Use macos_version?
     def macos13?
+      self.macos_version?(13)
       macos? && self['platform_version'].start_with?('13.')
     end
 
+    # DEPRECATED: Use macos_version?
     def macos14?
-      macos? && self['platform_version'].start_with?('14.')
+      self.macos_version?(14)
     end
 
+    # DEPRECATED: Use macos_version?
+    # This function... has never worked. You can't >= a string...
     def macos15v4plus?
       macos? && self['platform_version'] >= '15.4'
     end
 
+    # DEPRECATED: Use macos_version?
     def macos15?
-      macos? && self['platform_version'].start_with?('15.')
+      self.macos_version?(15)
     end
+
+    # DO NOT ADD ADDITIONAL macosXX? methods, use maco_version?
 
     def mac_mini_2018?
       macos? && self['hardware']['machine_model'] == 'Macmini8,1'
@@ -478,7 +606,8 @@ class Chef
     end
 
     def windows10_or_newer?
-      windows_desktop? && self._self_version >= self._canonical_version('10.0.1')
+      windows_desktop? &&
+        self._self_version >= self._canonical_version('10.0.1')
     end
 
     def windows_server?
@@ -555,59 +684,76 @@ class Chef
     end
 
     def windows2016_or_newer?
-      windows_server? && self._self_version >= self._canonical_version('10.0.14393')
+      windows_server? &&
+        self._self_version >= self._canonical_version('10.0.14393')
     end
 
     def windows2019_or_newer?
-      windows_server? && self._self_version >= self._canonical_version('10.0.17763')
+      windows_server? &&
+        self._self_version >= self._canonical_version('10.0.17763')
     end
 
     def windows2022_or_newer?
-      windows_server? && self._self_version >= self._canonical_version('10.0.20348')
+      windows_server? &&
+        self._self_version >= self._canonical_version('10.0.20348')
     end
 
     def windows2025_or_newer?
-      windows_server? && self._self_version >= self._canonical_version('10.0.26100')
+      windows_server? &&
+        self._self_version >= self._canonical_version('10.0.26100')
     end
 
     def windows2012_or_older?
-      windows_server? && self._self_version < self._canonical_version('6.3')
+      windows_server? &&
+        self._self_version < self._canonical_version('6.3')
     end
 
     def windows2012r2_or_older?
-      windows_server? && self._self_version < self._canonical_version('6.4')
+      windows_server? &&
+        self._self_version < self._canonical_version('6.4')
     end
 
     def windows2016_or_older?
-      windows_server? && self._self_version <= self._canonical_version('10.0.14393')
+      windows_server? &&
+        self._self_version <= self._canonical_version('10.0.14393')
     end
 
     def windows2019_or_older?
-      windows_server? && self._self_version <= self._canonical_version('10.0.17763')
+      windows_server? &&
+        self._self_version <= self._canonical_version('10.0.17763')
     end
 
     def windows2022_or_older?
-      windows_server? && self._self_version <= self._canonical_version('10.0.20348')
+      windows_server? &&
+        self._self_version <= self._canonical_version('10.0.20348')
     end
 
     def windows2025_or_older?
-      windows_server? && self._self_version <= self._canonical_version('10.0.26100')
+      windows_server? &&
+        self._self_version <= self._canonical_version('10.0.26100')
     end
 
     def aristaeos?
       self['platform'] == 'arista_eos'
     end
 
+    def aristaeos_version_plus?(v)
+      self.aristaeos? && self.os_min_version?(v, true)
+    end
+
+    # DEPRECATED: Use aristaeos_version_plus?
     def aristaeos_4_28_or_newer?
-      self.aristaeos? && self._self_version >= self._canonical_version('4.28')
+      self.aristaeos_version_plus?('4.28')
     end
 
+    # DEPRECATED: Use aristaeos_version_plus?
     def aristaeos_4_30_or_newer?
-      self.aristaeos? && self._self_version >= self._canonical_version('4.30')
+      self.aristaeos_version_plus?('4.30')
     end
 
+    # DEPRECATED: Use aristaeos_version_plus?
     def aristaeos_4_32_or_newer?
-      self.aristaeos? && self._self_version >= self._canonical_version('4.32')
+      self.aristaeos_version_plus?('4.32')
     end
 
     def embedded?
@@ -1103,8 +1249,9 @@ class Chef
 
     # returns the version-release of an rpm installed, or nil if not present
     def rpm_version(name)
-      if (self.centos? && !self.centos7?) || self.fedora? || self.redhat8? || self.oracle8? || self.redhat9? ||
-        self.oracle9? || self.redhat10? || self.aristaeos_4_30_or_newer?
+      if (self.centos? && !self.centos7?) || self.fedora? || self.redhat8? ||
+          self.oracle8? || self.redhat9? || self.oracle9? || self.redhat10? ||
+          self.aristaeos_4_30_or_newer?
         # returns epoch.version
         v = Chef::Provider::Package::Dnf::PythonHelper.instance.
             package_query(:whatinstalled, name).version

--- a/cookbooks/fb_helpers/spec/os_version_spec.rb
+++ b/cookbooks/fb_helpers/spec/os_version_spec.rb
@@ -25,8 +25,8 @@ describe 'Chef::Node' do
 
   context 'Any OS v 8.2' do
     before(:each) do
-      node.default['platform_version'] = '8.2'
-      node.default['platform_family'] = 'rhel'
+      node.automatic['platform_version'] = '8.2'
+      node.automatic['platform_family'] = 'rhel'
     end
 
     it 'should report correct version' do
@@ -95,9 +95,9 @@ describe 'Chef::Node' do
 
   context 'Ubuntu 24.04' do
     before(:each) do
-      node.default['platform_version'] = '24.04'
-      node.default['platform_family'] = 'debian'
-      node.default['platform'] = 'ubuntu'
+      node.automatic['platform_version'] = '24.04'
+      node.automatic['platform_family'] = 'debian'
+      node.automatic['platform'] = 'ubuntu'
     end
 
     it 'should report correct version' do
@@ -179,13 +179,103 @@ describe 'Chef::Node' do
         expect(node.os_max_version?(23.9, true)).to eq(false)
       end
     end
+
+    context 'Chef::Node.ubuntu_version?' do
+      it 'should handle major versions properly' do
+        {
+          23 => false,
+          24 => true,
+          25 => false,
+        }.each do |v, r|
+          expect(node.ubuntu_version?(v)).to eq(r)
+          expect(node.ubuntu_version?(v.to_s)).to eq(r)
+        end
+      end
+
+      it 'should handle minor versions properly' do
+        {
+          '23.04' => false,
+          '24.01' => false,
+          '24.04' => true,
+          '24.10' => false,
+          '25.04' => false,
+        }.each do |v, r|
+          expect(node.ubuntu_version?(v)).to eq(r)
+          expect(node.ubuntu_version?(v.to_f)).to eq(r)
+        end
+      end
+    end
+  end
+
+  context 'Fedora 39' do
+    before(:each) do
+      node.automatic['platform_version'] = '39'
+      node.automatic['platform_family'] = 'fedora'
+      node.automatic['platform'] = 'fedora'
+    end
+
+    context 'Chef::Node.fedora_version?' do
+      it 'handles versions correctly' do
+        {
+          37 => false,
+          38 => false,
+          39 => true,
+          40 => false,
+        }.each do |v, r|
+          expect(node.fedora_version?(v)).to eq(r)
+          expect(node.fedora_version?(v.to_s)).to eq(r)
+        end
+      end
+    end
+  end
+
+  context 'CentOS 9' do
+    before(:each) do
+      node.automatic['platform_version'] = '9'
+      node.automatic['platform_family'] = 'rhel'
+      node.automatic['platform'] = 'centos'
+    end
+
+    context 'Chef::Node.centos_version?' do
+      it 'handles versions correctly' do
+        expect(node.centos_version?(8)).to eq(false)
+        expect(node.centos_version?(9)).to eq(true)
+        expect(node.centos_version?(10)).to eq(false)
+
+        expect(node.centos_version?(9.1)).to eq(false)
+        expect(node.centos_version?(9.2)).to eq(false)
+      end
+    end
+  end
+
+  context 'CentOS 9.1' do
+    before(:each) do
+      node.automatic['platform_version'] = '9.1'
+      node.automatic['platform_family'] = 'rhel'
+      node.automatic['platform'] = 'centos'
+    end
+
+    context 'Chef::Node.centos_version?' do
+      it 'handles versions correctly' do
+        {
+          8 => false,
+          9 => true,
+          9.0 => false,
+          9.1 => true,
+          9.2 => false,
+        }.each do |v, r|
+          expect(node.centos_version?(v)).to eq(r)
+          expect(node.centos_version?(v.to_s)).to eq(r)
+        end
+      end
+    end
   end
 
   context 'Debian sid' do
     before(:each) do
-      node.default['platform_version'] = 'trixie/sid'
-      node.default['platform_family'] = 'debian'
-      node.default['platform'] = 'debian'
+      node.automatic['platform_version'] = 'trixie/sid'
+      node.automatic['platform_family'] = 'debian'
+      node.automatic['platform'] = 'debian'
     end
 
     it 'should report correct version' do
@@ -195,6 +285,29 @@ describe 'Chef::Node' do
     context 'Chef::Node.debian_min_version?' do
       it 'should be min anything' do
         expect(node.debian_min_version?(999)).to eq(true)
+      end
+    end
+  end
+
+  context 'Arista EOS 4.31' do
+    before(:each) do
+      node.automatic['platform_version'] = '4.31'
+      node.automatic['platform_family'] = 'arista_eos'
+      node.automatic['platform'] = 'arista_eos'
+    end
+
+    context 'Chef::Node.aristaeos_version_plus?' do
+      it 'handles versions correctly' do
+        {
+          '4.28' => true,
+          '4.30' => true,
+          '4.31' => true,
+          '4.32' => false,
+          '4.50' => false,
+          '5' => false,
+        }.each do |v, r|
+          expect(node.aristaeos_version_plus?(v)).to eq(r)
+        end
       end
     end
   end


### PR DESCRIPTION
I went to start adding missing version of all our osXX? version wrappers but then I thought - this isn't sustainable, we should come up with something better. We already have like centos10? but not rhel10? for example. We can do better.

So instead this if a new approach. For each platform we create a new _v method which will work for all versions. This is how it works:

* Create fedora_v?() which you can pass 39, 40, 41 to, etc.
* Turn fedoraXX? methods to just call the above, and mark them deprecated

And repeat for all platforms which we had these functions.

This also clears up rhel? vs rhel_family? (which were the same, but not made clear) and redhat?

It also fixes the tests which were setting node.default, but ohai attrs are node.automatic.

And final note: I didn't do windows helpers because their versions don't map directly, so there's no nice way to do it.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
