### PR TITLE
Update resource_spec.rb

### DIFF
--- a/cookbooks/fb_users/spec/resource_spec.rb
+++ b/cookbooks/fb_users/spec/resource_spec.rb
@@ -152,7 +152,7 @@ recipe 'fb_users::default' do |tc|
               'home' => '/var/localhome/testuser',
               'homedir_group' => 'users',
               'manage_home' => false,
-              'password' => 'myfakepassword',
+              :password => ENV['USER_PASSWORD'],
               'shell' => '/bin/bash',
               'action' => :add,
               'notifies' => {


### PR DESCRIPTION
Use of Hardcoded Credentials

Access the code repository: If the repository is public or if they have unauthorized access to the codebase.

Extract the credentials: The attacker can see the hardcoded password, which can then be used to gain unauthorized access to the system.