### PR TITLE
[fb_apt] Move sources.d cleanup to compile_time

### DIFF
--- a/cookbooks/fb_apt/recipes/default.rb
+++ b/cookbooks/fb_apt/recipes/default.rb
@@ -88,6 +88,7 @@ Dir.glob('/etc/apt/sources.list.d/*').each do |f|
   file f do
     not_if { node['fb_apt']['preserve_sources_list_d'] }
     action :delete
+    compile_time true
   end
 end
 


### PR DESCRIPTION
Packages can drop things into sources.d that conflict with what is
installed, and any package early resource will than crash the chef run,
so we should clean this up early in the run.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
