### PR TITLE
Minor Universe Fixes

### DIFF
--- a/scripts/chef_md_extract.rb
+++ b/scripts/chef_md_extract.rb
@@ -25,9 +25,13 @@ define_method(what) do |a|
   print a, ' '
 end
 
+# Disable Ruby warnings about redefining method_missing
+old_v = $VERBOSE
+$VERBOSE = nil
 # rubocop:disable Style/MethodMissing, Style/MissingRespondToMissing
 def method_missing(*keys); end
 # rubocop:enable Style/MethodMissing, Style/MissingRespondToMissing
+$VERBOSE = old_v
 
 # grab only the lines that call our method
 lines = []

--- a/scripts/copy_upstream_cookbooks
+++ b/scripts/copy_upstream_cookbooks
@@ -33,6 +33,11 @@ debug() {
     echo "DEBUG: $*" >&2
 }
 
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
 find_deps() {
     dir="$1"
     deps=()
@@ -41,7 +46,7 @@ find_deps() {
     # and add any we don't have to deps
     for file in "$dir"/cookbooks/*/metadata.rb; do
         # shellcheck disable=SC2207
-        if ! tdeps=($("$dir/scripts/chef_md_extract.rb" 'depends' "$file"));
+        if ! tdeps=($("chef-cookbooks/scripts/chef_md_extract.rb" 'depends' "$file"));
  then
             die "Failed to parse deps from $file"
         fi


### PR DESCRIPTION
* one of the things I did in my version of md_extract was supress
a ton of Ruby warnings, adding that to the upstream version as well
* Fix a bug in copy_upstream_cookbooks that pulls that script from
the wrong path

Signed-off-by: Phil Dibowitz <phil@ipom.com>
