### PR TITLE
Add support for JSON recipes

### DIFF
--- a/cookbooks/fb_helpers/README.md
+++ b/cookbooks/fb_helpers/README.md
@@ -552,6 +552,11 @@ your node.
     pass `CHEF_BOOT_SERVICE=true` as an environment variable from your
     boot-time chef invocation.
 
+* `node.json_recipes_support?`
+    A check on if JSON recipes are supported. Will eventually use the
+    backport mechanism in this cookbook, but for now just checks the
+    version numbers.
+
 ### FB::Helpers
 The following constants are available:
 

--- a/cookbooks/fb_helpers/libraries/json_recipes_monkeypatch.rb
+++ b/cookbooks/fb_helpers/libraries/json_recipes_monkeypatch.rb
@@ -1,0 +1,89 @@
+#
+# Monkey patches to bring https://github.com/chef/chef/pull/15094
+# into older Chef
+#
+if Chef::VERSION < '16'
+  # The `from_hash` functionality that YAML and JSON recipes use was added in Chef 16
+  Chef::Log.warn('[fb_helpers] Not loading JSON recipe monkeypatch,')
+  Chef::Log.warn('[fb_helpers] unsupported below Chef client version 16')
+  return
+elsif Chef::VERSION >= '19.1.53' || Chef::VERSION >= '18.7.28'
+  Chef::Log.info('[fb_helpers] Not loading JSON recipe monkeypatch,')
+  Chef::Log.info("[fb_helpers] since it's already in this version of Chef")
+  return
+end
+Chef::Log.info('[fb_helpers] Loading JSON recipe monkeypatch')
+
+# rubocop:disable all
+class Chef
+  class CookbookVersion
+    # Note - this is the only modified method on the upstream release
+    def load_recipe(recipe_name, run_context)
+      if recipe_filenames_by_name.key?(recipe_name)
+        load_ruby_recipe(recipe_name, run_context)
+      elsif recipe_yml_filenames_by_name.key?(recipe_name)
+        load_yml_recipe(recipe_name, run_context)
+      elsif recipe_json_filenames_by_name.key?(recipe_name)
+        load_json_recipe(recipe_name, run_context)
+      else
+        raise Chef::Exceptions::RecipeNotFound, "could not find recipe #{recipe_name} for cookbook #{name}"
+      end
+    end
+
+    def recipe_json_filenames_by_name
+      @recipe_json_filenames_by_name ||= begin
+        name_map = json_filenames_by_name(files_for("recipes"))
+        root_alias = cookbook_manifest.root_files.find { |record|
+          record[:name] == "root_files/recipe.json"
+        }
+        if root_alias
+          Chef::Log.error("Cookbook #{name} contains both recipe.json and recipes/default.json, ignoring recipes/default.json"
+) if name_map["default"]
+          name_map["default"] = root_alias[:full_path]
+        end
+        name_map
+      end
+    end
+
+    def load_json_recipe(recipe_name, run_context)
+      Chef::Log.trace("Found recipe #{recipe_name} in cookbook #{name}")
+      recipe = Chef::Recipe.new(name, recipe_name, run_context)
+      recipe_filename = recipe_json_filenames_by_name[recipe_name]
+
+      unless recipe_filename
+        raise Chef::Exceptions::RecipeNotFound, "could not find #{recipe_name} files for cookbook #{name}"
+      end
+
+      recipe.from_json_file(recipe_filename)
+      recipe
+    end
+
+    # Filters JSON files from the superset of provided files.
+    def json_filenames_by_name(records)
+      records.select { |record| record[:name].end_with?(".json") }.inject({}) { |memo, record| memo[File.basename(record[:name], ".json")] = record[:full_path]; memo }
+    end
+
+  end
+
+  class Recipe
+    def from_json_file(filename)
+      self.source_file = filename
+      if File.file?(filename) && File.readable?(filename)
+        json_contents = IO.read(filename)
+        from_json(json_contents)
+      else
+        raise IOError, "Cannot open or read file '#{filename}'!"
+      end
+    end
+
+    def from_json(string)
+      res = JSONCompat.from_json(string)
+      unless res.is_a?(Hash) && res.key?("resources")
+        raise ArgumentError, "JSON recipe '#{source_file}' must contain a top-level 'resources' hash"
+      end
+
+      from_hash(res)
+    end
+  end
+end
+

--- a/cookbooks/fb_helpers/libraries/node_methods.rb
+++ b/cookbooks/fb_helpers/libraries/node_methods.rb
@@ -1470,6 +1470,14 @@ class Chef
       false
     end
 
+    # JSON recipes are a fairly new Chef feature (as of August 2025), and we
+    # can't assume everyone is using them yet. To ensure there's no downstream breakage,
+    # we'll be using this method as a way to support Chef clients that don't include the backport
+    def json_recipes_supported?
+      return @json_recipes_supported unless @json_recipes_supported.nil?
+      @json_recipes_supported ||= Chef::VERSION >= '19.1.53' || Chef::VERSION >= '18.7.28'
+    end
+
     # A gate which can be used to limit dangerous code to only run during
     # provisioning or upon boot
     def disruptable?

--- a/cookbooks/test_services/recipes/default.rb
+++ b/cookbooks/test_services/recipes/default.rb
@@ -62,3 +62,8 @@ include_recipe 'fb_spamassassin'
 # Currently fb_reprepro is broken
 # https://github.com/facebook/chef-cookbooks/issues/78
 # include_recipe 'fb_reprepro'
+
+# Test JSON recipes
+if node.json_recipes_supported?
+  include_recipe '::test_json_recipe'
+end

--- a/cookbooks/test_services/recipes/test_json_recipe.json
+++ b/cookbooks/test_services/recipes/test_json_recipe.json
@@ -1,0 +1,9 @@
+{
+  "resources": [
+    {
+      "type": "log",
+      "name": "hello",
+      "message": "hello"
+    }
+  ]
+}


### PR DESCRIPTION
Summary:
I expect we'll be wanting to start using JSON recipes in our
open-source cookbooks pretty soon. This means having a path for
downstream users to either avoid using JSON recipes right away (we can keep the
old Ruby recipes for some period of time, gated by
`node.json_recipes_supported?`), or use JSON recipes on older clients by
including the `chef_json_recipes_backport` cookbook within their cookbooks.
While this patch is minimally invasive affecting one method, that method is
`load_recipe`, so that should be an opt-in effort for some amount of time
(maybe once Chef 19 has been on public release for a while).

Differential Revision: D79760668
