### PR TITLE
fb_apt: ensure keys are properly maintained

### DIFF
--- a/cookbooks/fb_apt/resources/keys.rb
+++ b/cookbooks/fb_apt/resources/keys.rb
@@ -81,6 +81,17 @@ action :run do
       notifies :run, "execute[generate #{name} keyring]", :immediately
     end
 
+    # If the dest file gets deleted but we don't need to update the
+    # src file, we'll never notice and never create the dest, so here's
+    # a special trigger just for that situation
+    ruby_block "force generation of #{dst}" do
+      # not_if, since it runs at run-time, will only trigger this
+      # if the above resource's 'immediate' notifies did not create it
+      not_if { ::File.exist?(dst) }
+      block { true }
+      notifies :run, "execute[generate #{name} keyring]", :immediately
+    end
+
     file dst do
       action :nothing
     end


### PR DESCRIPTION
The recent rewrite to handle updated key formats has a slight
corner-case problem.

If the destination of the key gets deleted for any reason, Chef won't
notice until the source is updated. This fixes that - idempotently, of
course.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
