### PR TITLE
Exclude spec from UseNodeDefault cop

### DIFF
--- a/.cookstyle.yml
+++ b/.cookstyle.yml
@@ -554,6 +554,8 @@ Chef/Meta/TimeshardIsValid:
 
 Chef/Meta/UseNodeDefault:
   Enabled: true
+  Exclude:
+    - !ruby/regexp /\/spec\//
 
 Chef/Meta/WindowsTaskAbsolutePaths:
   Enabled: true


### PR DESCRIPTION
Summary:
Spec files legitimately use node[] without node.default[], so exclude
them from the UseNodeDefault cop in the open-source cookstyle config. This addresses OSS CI
failures.

Differential Revision: D99126590


