### PR TITLE
Fix rubocop:ignore to rubocop:disable

### DIFF
--- a/.cookstyle.yml
+++ b/.cookstyle.yml
@@ -554,6 +554,8 @@ Chef/Meta/TimeshardIsValid:
 
 Chef/Meta/UseNodeDefault:
   Enabled: true
+  Exclude:
+    - !ruby/regexp /\/spec\//
 
 Chef/Meta/WindowsTaskAbsolutePaths:
   Enabled: true

--- a/cookbooks/fb_networkd/resources/default.rb
+++ b/cookbooks/fb_networkd/resources/default.rb
@@ -383,7 +383,7 @@ action :manage do
       execute "networkctl down #{iface}" do
         only_if { node.interface_change_allowed?(iface) }
         command "/bin/networkctl down #{iface}"
-        ignore_failure true # rubocop:ignore Chef/Meta/DontIgnoreFailures -- interface may already be down
+        ignore_failure true # rubocop:disable Chef/Meta/DontIgnoreFailures -- interface may already be down
         action :nothing
       end
 
@@ -407,7 +407,7 @@ action :manage do
       execute "udevadm trigger #{iface}" do
         only_if { node.interface_change_allowed?(iface) }
         command "/bin/udevadm trigger --action=add /sys/class/net/#{iface}"
-        ignore_failure true # rubocop:ignore Chef/Meta/DontIgnoreFailures -- if the device is already down, etc.
+        ignore_failure true # rubocop:disable Chef/Meta/DontIgnoreFailures -- if the device is already down, etc.
         action :nothing
       end
 
@@ -430,7 +430,7 @@ action :manage do
       execute "networkctl delete #{iface}" do
         only_if { node.interface_change_allowed?(iface) }
         command "/bin/networkctl delete #{iface}"
-        ignore_failure true # rubocop:ignore Chef/Meta/DontIgnoreFailures -- interface may already be down
+        ignore_failure true # rubocop:disable Chef/Meta/DontIgnoreFailures -- interface may already be down
         action :nothing
       end
 

--- a/cookbooks/fb_storage/resources/format_devices.rb
+++ b/cookbooks/fb_storage/resources/format_devices.rb
@@ -172,7 +172,7 @@ action :run do
         not_if { dev.start_with?('nvme') && max_hw_sectors_kb >= 1024 }
         type :int
         value max_sectors_kb
-        ignore_failure ignore_failure # rubocop:ignore Chef/Meta/DontIgnoreFailures
+        ignore_failure ignore_failure # rubocop:disable Chef/Meta/DontIgnoreFailures
       end
     end
   end

--- a/cookbooks/fb_systemd/resources/reload.rb
+++ b/cookbooks/fb_systemd/resources/reload.rb
@@ -77,7 +77,7 @@ action_class do
           # This can fail if the session is in a weird state, which is fine, as
           # it'll get respawned of the next login (which has the same effect
           # as running the action).
-          ignore_failure true # rubocop:ignore Chef/Meta/DontIgnoreFailures
+          ignore_failure true # rubocop:disable Chef/Meta/DontIgnoreFailures
         end
       end
       if failed


### PR DESCRIPTION
Summary:
rubocop:ignore is not valid rubocop syntax — the correct directive is
rubocop:disable. This fixes lint failures in fb_networkd, fb_storage,
and fb_systemd.

Differential Revision: D99135420


