### PR TITLE
Migrate fb_apache to use chefutils helpers

### DIFF
--- a/cookbooks/fb_apache/attributes/default.rb
+++ b/cookbooks/fb_apache/attributes/default.rb
@@ -23,7 +23,7 @@ moddir = value_for_platform_family(
   'debian' => '/usr/lib/apache2/modules',
 )
 
-auth_core_suffix = node.centos6? ? 'default' : 'core'
+auth_core_suffix = node.centos_version?(6) ? 'default' : 'core'
 
 modules = [
   'alias',
@@ -58,7 +58,7 @@ when 'rhel', 'fedora'
     'ssl',
   ]
 
-  unless node.centos6?
+  unless node.centos_version?(6)
     modules += [
       'socache_shmcb',
       'systemd',

--- a/cookbooks/fb_apache/recipes/default.rb
+++ b/cookbooks/fb_apache/recipes/default.rb
@@ -121,7 +121,7 @@ end
   end
 end
 
-if node.debian? || node.ubuntu?
+if node.chefutils.debian?
   # CentOS makes this symlink to the right module dir, and we make assumptions
   # it exists, so be sure to do the same on debian
   link '/etc/apache2/modules' do
@@ -143,7 +143,7 @@ fb_apache_cleanup_modules 'doit' do
 end
 
 template "#{moddir}/fb_modules.conf" do
-  not_if { node.centos6? }
+  not_if { node.centos_version?(6) }
   owner node.root_user
   group node.root_group
   mode '0644'
@@ -206,7 +206,7 @@ fb_apache_verify_configs 'doit' do
   action :nothing
 end
 
-if node['platform_family'] == 'debian'
+if node.chefutils.debian?
   # By default the apache package lays down a '000-default.conf' symlink to
   # sites-available/000-default.conf which contains a generic :80 listener.
   # This can conflict if we want to control :80 ourselves.

--- a/cookbooks/fb_apache/resources/verify_configs.rb
+++ b/cookbooks/fb_apache/resources/verify_configs.rb
@@ -73,7 +73,7 @@ action :verify do
     # resource collection and hence not track it for "updates".
     build_resource(:template,
                    "#{tdir}/#{new_resource.moddir}/fb_modules.conf") do
-      not_if { node.centos6? }
+      not_if { node.centos_version?(6) }
       owner 'root'
       group 'root'
       mode '0644'

--- a/cookbooks/fb_apache/templates/default/fb_apache.conf.erb
+++ b/cookbooks/fb_apache/templates/default/fb_apache.conf.erb
@@ -1,5 +1,5 @@
 # This file is controlled by Chef, do not edit!
-<%  if node.centos6? %>
+<%  if node.centos_version?(6) %>
 <%=   render 'apache_modules.erb' %>
 
 <%  end %>


### PR DESCRIPTION
Built on top of #364 - move fb_apache to use the helpers there.
