### PR TITLE
Add UpdateNodeMethod cop for config-driven node method renaming

### DIFF
--- a/.cookstyle.yml
+++ b/.cookstyle.yml
@@ -555,6 +555,14 @@ Chef/Meta/RemoteDirectoryWithoutPurge:
 Chef/Meta/TimeshardIsValid:
   Enabled: true
 
+# META: This should *only* be done on node methods that are in use in
+# fb_helpers/open-source cookbooks. Internal methods should be added in
+# the internal cookstyle configuration file. -dcrosby
+Chef/Meta/UpdateNodeMethod:
+  Enabled: true
+  Changes:
+    centos5?: 'centos_version?(5)'
+
 Chef/Meta/UseNodeDefault:
   Enabled: true
   Exclude:

--- a/cookbooks/fb_fluentbit/recipes/fluent-bit_default.rb
+++ b/cookbooks/fb_fluentbit/recipes/fluent-bit_default.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-unless node.rhel_family? || node.windows?
+unless node.rhel_family? || node.chefutils.windows?
   fail 'fb_fluentbit: unsupported platform. The list of supported platforms is
        [RHEL, windows]'
 end
@@ -62,7 +62,7 @@ state_dir = value_for_platform_family(
 directory 'runtime state directory' do
   action :create
   path state_dir
-  if node.windows?
+  if node.chefutils.windows?
     rights :full_control, 'Administrators'
   else
     owner node.root_user
@@ -72,13 +72,13 @@ directory 'runtime state directory' do
 end
 
 include_recipe 'fb_fluentbit::fluent-bit_rhel' if node.rhel_family?
-include_recipe 'fb_fluentbit::fluent-bit_windows' if node.windows?
+include_recipe 'fb_fluentbit::fluent-bit_windows' if node.chefutils.windows?
 
 template 'plugins config' do
   action :create
   source 'plugins.conf.erb'
   path plugins_file_path
-  if node.windows?
+  if node.chefutils.windows?
     rights :full_control, 'Administrators'
     notifies :restart, 'windows_service[FluentBit]'
   else
@@ -93,7 +93,7 @@ template 'parsers config' do
   action :create
   source 'parsers.conf.erb'
   path parsers_file_path
-  if node.windows?
+  if node.chefutils.windows?
     rights :full_control, 'Administrators'
     notifies :restart, 'windows_service[FluentBit]'
   else
@@ -109,7 +109,7 @@ remote_file 'remote config' do
   action :create
   source lazy { node['fb_fluentbit']['external_config_url'] }
   path main_file_path
-  if node.windows?
+  if node.chefutils.windows?
     rights :full_control, 'Administrators'
     notifies :restart, 'windows_service[FluentBit]'
   else
@@ -125,7 +125,7 @@ template 'local config' do
   action :create
   source 'conf.erb'
   path main_file_path
-  if node.windows?
+  if node.chefutils.windows?
     rights :full_control, 'Administrators'
     notifies :restart, 'windows_service[FluentBit]'
   else
@@ -136,7 +136,7 @@ template 'local config' do
   end
 end
 
-if node.windows?
+if node.chefutils.windows?
   windows_service 'FluentBit' do
     if node['fb_fluentbit']['custom_svc_restart_command']
       restart_command node['fb_fluentbit']['custom_svc_restart_command']

--- a/cookbooks/fb_fluentbit/recipes/td-agent-bit_default.rb
+++ b/cookbooks/fb_fluentbit/recipes/td-agent-bit_default.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-unless node.rhel_family? || node.windows?
+unless node.rhel_family? || node.chefutils.windows?
   fail 'fb_fluentbit: unsupported platform. The list of supported platforms is
        [RHEL_Family, windows]'
 end
@@ -62,7 +62,7 @@ state_dir = value_for_platform_family(
 directory 'runtime state directory' do
   action :create
   path state_dir
-  if node.windows?
+  if node.chefutils.windows?
     rights :full_control, 'Administrators'
   else
     owner node.root_user
@@ -72,13 +72,13 @@ directory 'runtime state directory' do
 end
 
 include_recipe 'fb_fluentbit::td-agent-bit_rhel' if node.rhel_family?
-include_recipe 'fb_fluentbit::td-agent-bit_windows' if node.windows?
+include_recipe 'fb_fluentbit::td-agent-bit_windows' if node.chefutils.windows?
 
 template 'plugins config' do
   action :create
   source 'plugins.conf.erb'
   path plugins_file_path
-  if node.windows?
+  if node.chefutils.windows?
     rights :full_control, 'Administrators'
     notifies :restart, 'windows_service[FluentBit]'
   else
@@ -93,7 +93,7 @@ template 'parsers config' do
   action :create
   source 'parsers.conf.erb'
   path parsers_file_path
-  if node.windows?
+  if node.chefutils.windows?
     rights :full_control, 'Administrators'
     notifies :restart, 'windows_service[FluentBit]'
   else
@@ -109,7 +109,7 @@ remote_file 'remote config' do
   action :create
   source lazy { node['fb_fluentbit']['external_config_url'] }
   path main_file_path
-  if node.windows?
+  if node.chefutils.windows?
     rights :full_control, 'Administrators'
     notifies :restart, 'windows_service[FluentBit]'
   else
@@ -125,7 +125,7 @@ template 'local config' do
   action :create
   source 'conf.erb'
   path main_file_path
-  if node.windows?
+  if node.chefutils.windows?
     rights :full_control, 'Administrators'
     notifies :restart, 'windows_service[FluentBit]'
   else
@@ -136,7 +136,7 @@ template 'local config' do
   end
 end
 
-if node.windows?
+if node.chefutils.windows?
   windows_service 'FluentBit' do
     if node['fb_fluentbit']['custom_svc_restart_command']
       restart_command node['fb_fluentbit']['custom_svc_restart_command']

--- a/cookbooks/fb_ntp/recipes/default.rb
+++ b/cookbooks/fb_ntp/recipes/default.rb
@@ -33,7 +33,7 @@ if node.macos?
 end
 
 whyrun_safe_ruby_block 'enforce ACL hardening' do
-  not_if { node.windows? }
+  not_if { node.chefutils.windows? }
   block do
     # Prepend this to whatever default the end-user overrode
     acl_entries = [
@@ -68,7 +68,7 @@ whyrun_safe_ruby_block 'enforce ACL hardening' do
 end
 
 template '/etc/ntp.conf' do
-  not_if { node.windows? }
+  not_if { node.chefutils.windows? }
   source 'ntp.conf.erb'
   owner node.root_user
   group node.root_group
@@ -110,7 +110,7 @@ end
 # You can't configure the service unless it's up, so this has to be
 # *after* the `service` call above. It does need to notify the service
 # as the commands make the change live and persistent.
-if node.windows?
+if node.chefutils.windows?
   fb_ntp_windows_config 'doit'
 end
 

--- a/cookstyle/UpdateNodeMethod.rb
+++ b/cookstyle/UpdateNodeMethod.rb
@@ -1,0 +1,48 @@
+# Copyright (c) 2026-present, Meta Platforms, Inc. and affiliates
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module RuboCop::Cop::Chef::Meta
+  class UpdateNodeMethod < Base
+    extend AutoCorrector
+
+    MSG = fb_msg('This node method should be updated to its replacement')
+    MSG_LVAR = fb_msg(
+      'This node method should be updated to its replacement ' +
+      '(assuming this is a Chef::Node object)',
+    )
+
+    def changes
+      cop_config['Changes'] || {}
+    end
+
+    def on_send(node)
+      return unless node.receiver
+      lvar = node.receiver.lvar_type? && node.receiver.source == 'node'
+      return unless node.self_receiver? ||
+        (node.receiver.send_type? && node.receiver.method?(:node)) ||
+        lvar
+      replacement_method = changes[node.method_name.to_s]
+      return unless replacement_method
+
+      msg = lvar ? MSG_LVAR : MSG
+      add_offense(node, :message => msg, :severity => :warning) do |corrector|
+        corrector.replace(
+          node.loc.selector,
+          replacement_method,
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Summary:
New cookstyle cop that reads a Changes hash from e.g. cookstyle.yml to
mechanically replace node method calls with their replacements via
autocorrect.

The benefits to this over a manual search-and-replace is that it can catch new
usage over time, and operates within the cookstyle lint/correction loop.

Differential Revision: D106402367


