### PR TITLE
Fix ChefUtilsProxy class

### DIFF
--- a/cookbooks/fb_helpers/libraries/node_methods.rb
+++ b/cookbooks/fb_helpers/libraries/node_methods.rb
@@ -26,7 +26,7 @@ class ChefUtilsProxy
     @node = node
   end
 
-  def __getnode
+  def __getnode(_skip_global = false)
     @node
   end
 end
@@ -38,7 +38,9 @@ class Chef
     # A way to explicitly call a ChefUtils function instead of a
     # fb_helpers function to aid in migration
     def chefutils
-      ChefUtilsProxy.new(self)
+      # rubocop:disable Naming/MemoizedInstanceVariableName
+      @_fb_helpers_chefutils_proxy ||= ChefUtilsProxy.new(self)
+      # rubocop:enable Naming/MemoizedInstanceVariableName
     end
 
     def linux?


### PR DESCRIPTION
There were two bugs in the initial implementation:

1. When called from a context without a proper node object, like a
library, `__getnode` was called with an arguement, as Chef does, but
we didn't take one.

2. We were re-instantiating the class on every call which is silly

Signed-off-by: Phil Dibowitz <phil@ipom.com>
