### PR TITLE
Fix fb_bind perms

### DIFF
--- a/cookbooks/fb_bind/recipes/default.rb
+++ b/cookbooks/fb_bind/recipes/default.rb
@@ -122,7 +122,7 @@ primary_dir = ::File.join(zones_dir, 'primary')
 directory primary_dir do
   owner node.root_group
   group usrgrp
-  mode '0755'
+  mode '0775'
 end
 
 fb_bind_zonefiles 'doit' do


### PR DESCRIPTION
The group needs access to the primary folder to be able to write out
signed files.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
