### PR TITLE
Fix lint.

### DIFF
--- a/cookbooks/fb_swap/README.md
+++ b/cookbooks/fb_swap/README.md
@@ -88,7 +88,8 @@ to a warning, use:
 node.default['fb_swap']['strict'] = false
 ```
 
-* btrfs root filesystem is not supported until https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ed46ff3d423780fa5173b38a844bf0fdb210a2a7
+* btrfs root filesystem is not supported until
+  https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ed46ff3d423780fa5173b38a844bf0fdb210a2a7
 * If any device(s) belonging to the root filesystem are rotational, using a
   swap file is not recommended.
 


### PR DESCRIPTION
MDL 0.16.0 fixes many bugs in MD013, both false positives and false
negatives. This line was a false negative and now fails on MDL 0.16.0.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
