### PR TITLE
Fix ChefUtils migration PR

### DIFF
--- a/cookbooks/fb_apache/recipes/default.rb
+++ b/cookbooks/fb_apache/recipes/default.rb
@@ -121,7 +121,7 @@ end
   end
 end
 
-if node.chefutils.debian?
+if ChefUtils.debian?
   # CentOS makes this symlink to the right module dir, and we make assumptions
   # it exists, so be sure to do the same on debian
   link '/etc/apache2/modules' do
@@ -206,7 +206,7 @@ fb_apache_verify_configs 'doit' do
   action :nothing
 end
 
-if node.chefutils.debian?
+if ChefUtils.debian?
   # By default the apache package lays down a '000-default.conf' symlink to
   # sites-available/000-default.conf which contains a generic :80 listener.
   # This can conflict if we want to control :80 ourselves.

--- a/cookbooks/fb_helpers/libraries/node_methods.rb
+++ b/cookbooks/fb_helpers/libraries/node_methods.rb
@@ -1346,7 +1346,7 @@ class Chef
     end
 
     def host_chef_base_path
-      if self.chefutils.windows?
+      if ChefUtils.windows?
         File.join('C:', 'chef')
       else
         File.join('/var', 'chef')
@@ -1354,7 +1354,7 @@ class Chef
     end
 
     def solo_chef_base_path
-      if self.chefutils.windows?
+      if ChefUtils.windows?
         File.join('C:', 'chef', 'solo')
       else
         File.join('/opt', 'chef-solo')


### PR DESCRIPTION
It turns out there's a far cleaner way to do this migration. We can
reference ChefUtils.<function> directly from anywhere.

So, convert the only two callers in the codebase. Cannot yet remove
the proxy since callers are not all in the same cookbook and cookbook
uploads are not atomic. Next PR will remove the class. Then I'll update
my other PRs.

I tested this in Chef 16 and Chef 18, here's the 16 version for
reference:

```
[2026-06-02T14:23:36-07:00] INFO: *** Cinc Client 16.18.0 ***

CU-TEST:ATTRIBUTES
  ChefUtils.rhel? false
  [fb_helpers:rhel_family]   rhel? false
  [fb_helpers:rhel_family]   node.rhel? false
CU-TEST:RECIPE
  ChefUtils.rhel? false
  rhel? false
  [fb_helpers:rhel_family]   node.rhel? false
  ChefUtils.windows? false
  windows? false
  [fb_helpers:windows]   node.windows? false
  ChefUtils.debian? true
  debian? true
  [fb_helpers:debian]   node.debian? true
CU-TEST:LIBRARY
  ChefUtils.rhel? false
  rhel? false
  [fb_helpers:rhel_family]   node.rhel? false
  ChefUtils.windows? false
  windows? false
  [fb_helpers:windows]   node.windows? false
  ChefUtils.debian? true
  debian? true
  [fb_helpers:debian]   node.debian? true
CU-TEST:FB_HELPERS_NODE_LIBRARY
  ChefUtils.rhel? false
  [fb_helpers:rhel_family]   rhel? false
  [fb_helpers:rhel_family]   node.rhel? false
  ChefUtils.windows? false
  [fb_helpers:windows]   windows? false
  [fb_helpers:windows]   node.windows? false
  ChefUtils.debian? true
  [fb_helpers:debian]   debian? true
  [fb_helpers:debian]   node.debian? true
CU-TEST:TEMPLATE
  ChefUtils.rhel? false
  rhel? <cannot be called from a template>
  [fb_helpers:rhel_family]   node.rhel? false
  ChefUtils.windows? false
  windows? <cannot be called from a template>
  [fb_helpers:windows]   node.windows? false
  ChefUtils.debian? true
  debian? <cannot be called from a template>
  [fb_helpers:debian]   node.windows? true
```

Signed-off-by: Phil Dibowitz <phil@ipom.com>
