### PR TITLE
Remove the [unnused] chefutils proxy class

### DIFF
--- a/cookbooks/fb_helpers/libraries/node_methods.rb
+++ b/cookbooks/fb_helpers/libraries/node_methods.rb
@@ -19,29 +19,9 @@
 # Reference: Chef platform_family values
 # https://docs.chef.io/infra_language/checking_platforms/#platform_family-values
 
-class ChefUtilsProxy
-  include ChefUtils
-
-  def initialize(node)
-    @node = node
-  end
-
-  def __getnode(_skip_global = false)
-    @node
-  end
-end
-
 class Chef
   # Our extensions of the node object
   class Node
-
-    # A way to explicitly call a ChefUtils function instead of a
-    # fb_helpers function to aid in migration
-    def chefutils
-      # rubocop:disable Naming/MemoizedInstanceVariableName
-      @_fb_helpers_chefutils_proxy ||= ChefUtilsProxy.new(self)
-      # rubocop:enable Naming/MemoizedInstanceVariableName
-    end
 
     def linux?
       return @_fb_helpers_linux unless @_fb_helpers_linux.nil?

--- a/cookbooks/fb_helpers/spec/node_spec.rb
+++ b/cookbooks/fb_helpers/spec/node_spec.rb
@@ -315,35 +315,6 @@ describe 'Chef::Node' do
     end
   end
 
-  context 'Chef::Node.chefutils' do
-    it 'returns true for debian? when platform_family is debian' do
-      node.automatic['platform'] = 'debian'
-      node.automatic['platform_family'] = 'debian'
-      expect(node.chefutils.debian?).to be(true)
-    end
-
-    it 'returns false for debian? when platform_family is not debian' do
-      node.automatic['platform'] = 'centos'
-      node.automatic['platform_family'] = 'rhel'
-      expect(node.chefutils.debian?).to be(false)
-    end
-
-    it 'differs from node.debian? for ubuntu (platform_family=debian, platform=ubuntu)' do
-      node.automatic['platform'] = 'ubuntu'
-      node.automatic['platform_family'] = 'debian'
-      # fb_helpers checks platform == 'debian', so ubuntu is false
-      expect(node.debian?).to be(false)
-      # ChefUtils checks platform_family == 'debian', so ubuntu is true
-      expect(node.chefutils.debian?).to be(true)
-    end
-
-    it 'returns true for rhel? when platform_family is rhel' do
-      node.automatic['platform'] = 'centos'
-      node.automatic['platform_family'] = 'rhel'
-      expect(node.chefutils.rhel?).to be(true)
-    end
-  end
-
   context 'Chef::Node.disruptable?' do
     it 'is not disruptable by default' do
       expect(node.disruptable?).to be(false)


### PR DESCRIPTION
No longer needed.


Signed-off-by: Phil Dibowitz <phil@ipom.com>
